### PR TITLE
Update logion types

### DIFF
--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.5.0-1",
+  "version": "0.5.0-2",
   "description": "logion API",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/node-api/src/interfaces/augment-api-events.ts
+++ b/packages/node-api/src/interfaces/augment-api-events.ts
@@ -8,7 +8,7 @@ import '@polkadot/api-base/types/events';
 import type { ApiTypes, AugmentedEvent } from '@polkadot/api-base/types';
 import type { Bytes, Null, Option, Result, U8aFixed, Vec, bool, u128, u32, u64, u8 } from '@polkadot/types-codec';
 import type { ITuple } from '@polkadot/types-codec/types';
-import type { OpaquePeerId } from '@polkadot/types/interfaces/imOnline';
+import type { OpaquePeerId } from './default';
 import type { AccountId32, H256 } from '@polkadot/types/interfaces/runtime';
 import type { FrameSupportTokensMiscBalanceStatus, FrameSupportWeightsDispatchInfo, PalletMultisigTimepoint, SpFinalityGrandpaAppPublic, SpRuntimeDispatchError } from '@polkadot/types/lookup';
 

--- a/packages/node-api/src/interfaces/augment-api-query.ts
+++ b/packages/node-api/src/interfaces/augment-api-query.ts
@@ -8,7 +8,7 @@ import '@polkadot/api-base/types/storage';
 import type { ApiTypes, AugmentedQuery, QueryableStorageEntry } from '@polkadot/api-base/types';
 import type { BTreeSet, Bytes, Option, U8aFixed, Vec, WrapperKeepOpaque, bool, u128, u32, u64 } from '@polkadot/types-codec';
 import type { AnyNumber, ITuple } from '@polkadot/types-codec/types';
-import type { OpaquePeerId } from '@polkadot/types/interfaces/imOnline';
+import type { OpaquePeerId } from './default';
 import type { AccountId32, Call, H256 } from '@polkadot/types/interfaces/runtime';
 import type { FrameSupportWeightsPerDispatchClassU64, FrameSystemAccountInfo, FrameSystemEventRecord, FrameSystemLastRuntimeUpgradeInfo, FrameSystemPhase, LogionNodeRuntimeOpaqueSessionKeys, PalletAssetsApproval, PalletAssetsAssetAccount, PalletAssetsAssetDetails, PalletAssetsAssetMetadata, PalletBalancesAccountData, PalletBalancesBalanceLock, PalletBalancesReleases, PalletBalancesReserveData, PalletGrandpaStoredPendingChange, PalletGrandpaStoredState, PalletLoAuthorityListLegalOfficerData, PalletLoAuthorityListStorageVersion, PalletLogionLocCollectionItem, PalletLogionLocLegalOfficerCase, PalletLogionLocStorageVersion, PalletMultisigMultisig, PalletRecoveryActiveRecovery, PalletRecoveryRecoveryConfig, PalletTransactionPaymentReleases, SpConsensusAuraSr25519AppSr25519Public, SpCoreCryptoKeyTypeId, SpRuntimeDigest } from '@polkadot/types/lookup';
 import type { Observable } from '@polkadot/types/types';
@@ -207,11 +207,11 @@ declare module '@polkadot/api-base/types/storage' {
       /**
        * The additional adapative connections of each node.
        **/
-      additionalConnections: AugmentedQuery<ApiType, (arg: OpaquePeerId | object | string | Uint8Array) => Observable<BTreeSet<OpaquePeerId>>, [OpaquePeerId]> & QueryableStorageEntry<ApiType, [OpaquePeerId]>;
+      additionalConnections: AugmentedQuery<ApiType, (arg: OpaquePeerId | string | Uint8Array) => Observable<BTreeSet<OpaquePeerId>>, [OpaquePeerId]> & QueryableStorageEntry<ApiType, [OpaquePeerId]>;
       /**
        * A map that maintains the ownership of each node.
        **/
-      owners: AugmentedQuery<ApiType, (arg: OpaquePeerId | object | string | Uint8Array) => Observable<Option<AccountId32>>, [OpaquePeerId]> & QueryableStorageEntry<ApiType, [OpaquePeerId]>;
+      owners: AugmentedQuery<ApiType, (arg: OpaquePeerId | string | Uint8Array) => Observable<Option<AccountId32>>, [OpaquePeerId]> & QueryableStorageEntry<ApiType, [OpaquePeerId]>;
       /**
        * The set of well known nodes. This is stored sorted (just by value).
        **/

--- a/packages/node-api/src/interfaces/augment-api-tx.ts
+++ b/packages/node-api/src/interfaces/augment-api-tx.ts
@@ -8,7 +8,7 @@ import '@polkadot/api-base/types/submittable';
 import type { ApiTypes, AugmentedSubmittable, SubmittableExtrinsic, SubmittableExtrinsicFunction } from '@polkadot/api-base/types';
 import type { Bytes, Compact, Option, U8aFixed, Vec, WrapperKeepOpaque, bool, u128, u16, u32, u64, u8 } from '@polkadot/types-codec';
 import type { AnyNumber, IMethod, ITuple } from '@polkadot/types-codec/types';
-import type { OpaquePeerId } from '@polkadot/types/interfaces/imOnline';
+import type { OpaquePeerId } from './default';
 import type { AccountId32, Call, H256, MultiAddress, Perbill } from '@polkadot/types/interfaces/runtime';
 import type { LogionNodeRuntimeOpaqueSessionKeys, PalletAssetsDestroyWitness, PalletLoAuthorityListLegalOfficerData, PalletLogionLocCollectionItemFile, PalletLogionLocCollectionItemToken, PalletLogionLocFile, PalletLogionLocLocLink, PalletLogionLocMetadataItem, PalletMultisigTimepoint, SpCoreVoid, SpFinalityGrandpaEquivocationProof } from '@polkadot/types/lookup';
 
@@ -804,7 +804,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * - `node`: identifier of the node.
        * - `connections`: additonal nodes from which the connections are allowed.
        **/
-      addConnections: AugmentedSubmittable<(node: OpaquePeerId | object | string | Uint8Array, connections: Vec<OpaquePeerId> | (OpaquePeerId | object | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, Vec<OpaquePeerId>]>;
+      addConnections: AugmentedSubmittable<(node: OpaquePeerId | string | Uint8Array, connections: Vec<OpaquePeerId> | (OpaquePeerId | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, Vec<OpaquePeerId>]>;
       /**
        * Add a node to the set of well known nodes. If the node is already claimed, the owner
        * will be updated and keep the existing additional connection unchanged.
@@ -813,14 +813,14 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * - `node`: identifier of the node.
        **/
-      addWellKnownNode: AugmentedSubmittable<(node: OpaquePeerId | object | string | Uint8Array, owner: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, AccountId32]>;
+      addWellKnownNode: AugmentedSubmittable<(node: OpaquePeerId | string | Uint8Array, owner: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, AccountId32]>;
       /**
        * A given node can be claimed by anyone. The owner should be the first to know its
        * PeerId, so claim it right away!
        * 
        * - `node`: identifier of the node.
        **/
-      claimNode: AugmentedSubmittable<(node: OpaquePeerId | object | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId]>;
+      claimNode: AugmentedSubmittable<(node: OpaquePeerId | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId]>;
       /**
        * A claim can be removed by its owner and get back the reservation. The additional
        * connections are also removed. You can't remove a claim on well known nodes, as it
@@ -828,14 +828,14 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * - `node`: identifier of the node.
        **/
-      removeClaim: AugmentedSubmittable<(node: OpaquePeerId | object | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId]>;
+      removeClaim: AugmentedSubmittable<(node: OpaquePeerId | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId]>;
       /**
        * Remove additional connections of a given node.
        * 
        * - `node`: identifier of the node.
        * - `connections`: additonal nodes from which the connections are not allowed anymore.
        **/
-      removeConnections: AugmentedSubmittable<(node: OpaquePeerId | object | string | Uint8Array, connections: Vec<OpaquePeerId> | (OpaquePeerId | object | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, Vec<OpaquePeerId>]>;
+      removeConnections: AugmentedSubmittable<(node: OpaquePeerId | string | Uint8Array, connections: Vec<OpaquePeerId> | (OpaquePeerId | string | Uint8Array)[]) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, Vec<OpaquePeerId>]>;
       /**
        * Remove a node from the set of well known nodes. The ownership and additional
        * connections of the node will also be removed.
@@ -844,7 +844,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * - `node`: identifier of the node.
        **/
-      removeWellKnownNode: AugmentedSubmittable<(node: OpaquePeerId | object | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId]>;
+      removeWellKnownNode: AugmentedSubmittable<(node: OpaquePeerId | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId]>;
       /**
        * Reset all the well known nodes. This will not remove the ownership and additional
        * connections for the removed nodes. The node owner can perform further cleaning if
@@ -854,7 +854,7 @@ declare module '@polkadot/api-base/types/submittable' {
        * 
        * - `nodes`: the new nodes for the allow list.
        **/
-      resetWellKnownNodes: AugmentedSubmittable<(nodes: Vec<ITuple<[OpaquePeerId, AccountId32]>> | ([OpaquePeerId | object | string | Uint8Array, AccountId32 | string | Uint8Array])[]) => SubmittableExtrinsic<ApiType>, [Vec<ITuple<[OpaquePeerId, AccountId32]>>]>;
+      resetWellKnownNodes: AugmentedSubmittable<(nodes: Vec<ITuple<[OpaquePeerId, AccountId32]>> | ([OpaquePeerId | string | Uint8Array, AccountId32 | string | Uint8Array])[]) => SubmittableExtrinsic<ApiType>, [Vec<ITuple<[OpaquePeerId, AccountId32]>>]>;
       /**
        * Swap a well known node to another. Both the ownership and additional connections
        * stay untouched.
@@ -864,14 +864,14 @@ declare module '@polkadot/api-base/types/submittable' {
        * - `remove`: the node which will be moved out from the list.
        * - `add`: the node which will be put in the list.
        **/
-      swapWellKnownNode: AugmentedSubmittable<(remove: OpaquePeerId | object | string | Uint8Array, add: OpaquePeerId | object | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, OpaquePeerId]>;
+      swapWellKnownNode: AugmentedSubmittable<(remove: OpaquePeerId | string | Uint8Array, add: OpaquePeerId | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, OpaquePeerId]>;
       /**
        * A node can be transferred to a new owner.
        * 
        * - `node`: identifier of the node.
        * - `owner`: new owner of the node.
        **/
-      transferNode: AugmentedSubmittable<(node: OpaquePeerId | object | string | Uint8Array, owner: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, AccountId32]>;
+      transferNode: AugmentedSubmittable<(node: OpaquePeerId | string | Uint8Array, owner: AccountId32 | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [OpaquePeerId, AccountId32]>;
       /**
        * Generic tx
        **/

--- a/packages/node-api/src/interfaces/augment-types.ts
+++ b/packages/node-api/src/interfaces/augment-types.ts
@@ -5,7 +5,7 @@
 // this is required to allow for ambient/previous definitions
 import '@polkadot/types/types/registry';
 
-import type { CollectionItem, CollectionItemFile, CollectionItemId, CollectionItemToken, CollectionSize, File, LegalOfficerCaseOf, LocId, LocLink, LocType, LocVoidInfo, MetadataItem, PeerId, Requester, StorageVersion } from '../interfaces/default';
+import type { CollectionItem, CollectionItemFile, CollectionItemId, CollectionItemToken, CollectionSize, File, LegalOfficerCaseOf, LegalOfficerData, LoAuthorityListStorageVersion, LocId, LocLink, LocType, LocVoidInfo, MetadataItem, OpaquePeerId, Requester, StorageVersion } from '../interfaces/default';
 import type { FullIdentification, IdentificationTuple, Keys, MembershipProof, SessionIndex, SessionKeys2, ValidatorCount } from '../interfaces/session';
 import type { Data, StorageKey } from '@polkadot/types';
 import type { BitVec, Bool, Bytes, F32, F64, I128, I16, I256, I32, I64, I8, Json, Null, OptionBool, Raw, Text, Type, U128, U16, U256, U32, U64, U8, USize, bool, f32, f64, i128, i16, i256, i32, i64, i8, u128, u16, u256, u32, u64, u8, usize } from '@polkadot/types-codec';
@@ -40,7 +40,7 @@ import type { AssetOptions, Owner, PermissionLatest, PermissionVersions, Permiss
 import type { ActiveGilt, ActiveGiltsTotal, ActiveIndex, GiltBid } from '@polkadot/types/interfaces/gilt';
 import type { AuthorityIndex, AuthorityList, AuthoritySet, AuthoritySetChange, AuthoritySetChanges, AuthorityWeight, DelayKind, DelayKindBest, EncodedFinalityProofs, ForkTreePendingChange, ForkTreePendingChangeNode, GrandpaCommit, GrandpaEquivocation, GrandpaEquivocationProof, GrandpaEquivocationValue, GrandpaJustification, GrandpaPrecommit, GrandpaPrevote, GrandpaSignedPrecommit, JustificationNotification, KeyOwnerProof, NextAuthority, PendingChange, PendingPause, PendingResume, Precommits, Prevotes, ReportedRoundStates, RoundState, SetId, StoredPendingChange, StoredState } from '@polkadot/types/interfaces/grandpa';
 import type { IdentityFields, IdentityInfo, IdentityInfoAdditional, IdentityInfoTo198, IdentityJudgement, RegistrarIndex, RegistrarInfo, Registration, RegistrationJudgement, RegistrationTo198 } from '@polkadot/types/interfaces/identity';
-import type { AuthIndex, AuthoritySignature, Heartbeat, HeartbeatTo244, OpaqueMultiaddr, OpaqueNetworkState, OpaquePeerId } from '@polkadot/types/interfaces/imOnline';
+import type { AuthIndex, AuthoritySignature, Heartbeat, HeartbeatTo244, OpaqueMultiaddr, OpaqueNetworkState } from '@polkadot/types/interfaces/imOnline';
 import type { CallIndex, LotteryConfig } from '@polkadot/types/interfaces/lottery';
 import type { ErrorMetadataLatest, ErrorMetadataV10, ErrorMetadataV11, ErrorMetadataV12, ErrorMetadataV13, ErrorMetadataV14, ErrorMetadataV9, EventMetadataLatest, EventMetadataV10, EventMetadataV11, EventMetadataV12, EventMetadataV13, EventMetadataV14, EventMetadataV9, ExtrinsicMetadataLatest, ExtrinsicMetadataV11, ExtrinsicMetadataV12, ExtrinsicMetadataV13, ExtrinsicMetadataV14, FunctionArgumentMetadataLatest, FunctionArgumentMetadataV10, FunctionArgumentMetadataV11, FunctionArgumentMetadataV12, FunctionArgumentMetadataV13, FunctionArgumentMetadataV14, FunctionArgumentMetadataV9, FunctionMetadataLatest, FunctionMetadataV10, FunctionMetadataV11, FunctionMetadataV12, FunctionMetadataV13, FunctionMetadataV14, FunctionMetadataV9, MetadataAll, MetadataLatest, MetadataV10, MetadataV11, MetadataV12, MetadataV13, MetadataV14, MetadataV9, ModuleConstantMetadataV10, ModuleConstantMetadataV11, ModuleConstantMetadataV12, ModuleConstantMetadataV13, ModuleConstantMetadataV9, ModuleMetadataV10, ModuleMetadataV11, ModuleMetadataV12, ModuleMetadataV13, ModuleMetadataV9, OpaqueMetadata, PalletCallMetadataLatest, PalletCallMetadataV14, PalletConstantMetadataLatest, PalletConstantMetadataV14, PalletErrorMetadataLatest, PalletErrorMetadataV14, PalletEventMetadataLatest, PalletEventMetadataV14, PalletMetadataLatest, PalletMetadataV14, PalletStorageMetadataLatest, PalletStorageMetadataV14, PortableType, PortableTypeV14, SignedExtensionMetadataLatest, SignedExtensionMetadataV14, StorageEntryMetadataLatest, StorageEntryMetadataV10, StorageEntryMetadataV11, StorageEntryMetadataV12, StorageEntryMetadataV13, StorageEntryMetadataV14, StorageEntryMetadataV9, StorageEntryModifierLatest, StorageEntryModifierV10, StorageEntryModifierV11, StorageEntryModifierV12, StorageEntryModifierV13, StorageEntryModifierV14, StorageEntryModifierV9, StorageEntryTypeLatest, StorageEntryTypeV10, StorageEntryTypeV11, StorageEntryTypeV12, StorageEntryTypeV13, StorageEntryTypeV14, StorageEntryTypeV9, StorageHasher, StorageHasherV10, StorageHasherV11, StorageHasherV12, StorageHasherV13, StorageHasherV14, StorageHasherV9, StorageMetadataV10, StorageMetadataV11, StorageMetadataV12, StorageMetadataV13, StorageMetadataV9 } from '@polkadot/types/interfaces/metadata';
 import type { MmrBatchProof, MmrEncodableOpaqueLeaf, MmrError, MmrLeafBatchProof, MmrLeafIndex, MmrLeafProof, MmrNodeIndex, MmrProof } from '@polkadot/types/interfaces/mmr';
@@ -610,8 +610,10 @@ declare module '@polkadot/types/types/registry' {
     LeasePeriodOf: LeasePeriodOf;
     LegacyTransaction: LegacyTransaction;
     LegalOfficerCaseOf: LegalOfficerCaseOf;
+    LegalOfficerData: LegalOfficerData;
     Limits: Limits;
     LimitsTo264: LimitsTo264;
+    LoAuthorityListStorageVersion: LoAuthorityListStorageVersion;
     LocalValidationData: LocalValidationData;
     LocId: LocId;
     LockIdentifier: LockIdentifier;
@@ -773,7 +775,6 @@ declare module '@polkadot/types/types/registry' {
     Peer: Peer;
     PeerEndpoint: PeerEndpoint;
     PeerEndpointAddr: PeerEndpointAddr;
-    PeerId: PeerId;
     PeerInfo: PeerInfo;
     PeerPing: PeerPing;
     PendingChange: PendingChange;

--- a/packages/node-api/src/interfaces/default/definitions.ts
+++ b/packages/node-api/src/interfaces/default/definitions.ts
@@ -1,9 +1,14 @@
 /* eslint-disable */
 export default {
+    typesAlias: {
+        loAuthorityList: {
+            StorageVersion: "LoAuthorityListStorageVersion",
+        }
+    },
     types: {
         Address: "MultiAddress",
         LookupSource: "MultiAddress",
-        PeerId: "(Vec<u8>)",
+        OpaquePeerId: "Vec<u8>",
         AccountInfo: "AccountInfoWithDualRefCount",
         TAssetBalance: "u128",
         AssetId: "u64",
@@ -40,6 +45,7 @@ export default {
             collection_last_block_submission: "Option<BlockNumber>",
             collection_max_size: "Option<CollectionSize>",
             collection_can_upload: "bool",
+            seal: "Option<Hash>",
         },
         MetadataItem: {
             name: "Vec<u8>",
@@ -73,6 +79,8 @@ export default {
                 "V4ItemSubmitter",
                 "V5Collection",
                 "V6ItemUpload",
+                "V7ItemToken",
+                "V8AddSeal",
             ]
         },
         Requester: {
@@ -99,6 +107,16 @@ export default {
         CollectionItemToken: {
             token_type: "Vec<u8>",
 	        token_id: "Vec<u8>",
-        }
+        },
+        LegalOfficerData: {
+            node_id: "Option<OpaquePeerId>",
+            base_url: "Option<Vec<u8>>",
+        },
+        LoAuthorityListStorageVersion: {
+            "_enum": [
+                "V1",
+                "V2AddOnchainSettings",
+            ]
+        },
     }
 };

--- a/packages/node-api/src/interfaces/default/types.ts
+++ b/packages/node-api/src/interfaces/default/types.ts
@@ -87,6 +87,20 @@ export interface LegalOfficerCaseOf extends Struct {
   readonly collection_last_block_submission: Option<BlockNumber>;
   readonly collection_max_size: Option<CollectionSize>;
   readonly collection_can_upload: bool;
+  readonly seal: Option<Hash>;
+}
+
+/** @name LegalOfficerData */
+export interface LegalOfficerData extends Struct {
+  readonly node_id: Option<OpaquePeerId>;
+  readonly base_url: Option<Bytes>;
+}
+
+/** @name LoAuthorityListStorageVersion */
+export interface LoAuthorityListStorageVersion extends Enum {
+  readonly isV1: boolean;
+  readonly isV2AddOnchainSettings: boolean;
+  readonly type: 'V1' | 'V2AddOnchainSettings';
 }
 
 /** @name LocId */
@@ -121,8 +135,8 @@ export interface MetadataItem extends Struct {
   readonly submitter: AccountId;
 }
 
-/** @name PeerId */
-export interface PeerId extends Bytes {}
+/** @name OpaquePeerId */
+export interface OpaquePeerId extends Bytes {}
 
 /** @name Requester */
 export interface Requester extends Enum {
@@ -142,7 +156,9 @@ export interface StorageVersion extends Enum {
   readonly isV4ItemSubmitter: boolean;
   readonly isV5Collection: boolean;
   readonly isV6ItemUpload: boolean;
-  readonly type: 'V1' | 'V2MakeLocVoid' | 'V3RequesterEnum' | 'V4ItemSubmitter' | 'V5Collection' | 'V6ItemUpload';
+  readonly isV7ItemToken: boolean;
+  readonly isV8AddSeal: boolean;
+  readonly type: 'V1' | 'V2MakeLocVoid' | 'V3RequesterEnum' | 'V4ItemSubmitter' | 'V5Collection' | 'V6ItemUpload' | 'V7ItemToken' | 'V8AddSeal';
 }
 
 /** @name TAssetBalance */


### PR DESCRIPTION
This PR introduces the new logion types for polkadot.js and fixes the encoding/decoding of peer IDs with `nodeAuthorization` and `loAuthorityList` pallets.

logion-network/logion-internal#575