### PR TITLE
MimeType now exposes extensions

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.14.0-3",
+  "version": "0.14.0-4",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Mime.ts
+++ b/packages/client/src/Mime.ts
@@ -1,4 +1,4 @@
-import mimeDb from 'mime-db';
+import mimeDb, { MimeEntry } from 'mime-db';
 
 export class MimeType {
 
@@ -7,20 +7,32 @@ export class MimeType {
     }
 
     constructor(mimeType: string) {
-        if(!isValidMime(mimeType)) {
+        const entry = getMimeDbEntry(mimeType);
+        if(!entry) {
             throw new Error(`Unknown mime type: ${mimeType}`);
         }
         this._mimeType = mimeType;
+        this._entry = entry;
     }
 
     private _mimeType: string;
 
+    private _entry: MimeEntry;
+
     get mimeType() {
         return this._mimeType;
+    }
+
+    get extensions(): ReadonlyArray<string> {
+        return this._entry.extensions || [];
     }
 }
 
 export function isValidMime(mimeType: string): boolean {
+    return getMimeDbEntry(mimeType) !== undefined;
+}
+
+function getMimeDbEntry(mimeType: string): MimeEntry | undefined {
     const parametersIndex = mimeType.indexOf(";");
     let simpleType;
     if(parametersIndex !== -1) {
@@ -28,5 +40,5 @@ export function isValidMime(mimeType: string): boolean {
     } else {
         simpleType = mimeType;
     }
-    return simpleType in mimeDb;
+    return mimeDb[simpleType];
 }

--- a/packages/client/test/Mime.spec.ts
+++ b/packages/client/test/Mime.spec.ts
@@ -6,16 +6,32 @@ describe("MimeType", () => {
         expect(() => MimeType.from("unknown/mime-type")).toThrow();
     });
 
-    it("creates known MIME type without charset", () => {
-        testValidMimeType("text/plain");
+    it("creates known MIME type without charset", () => testValidMimeType("text/plain"));
+    it("creates known MIME type with charset", () => testValidMimeType("text/plain;charset=utf-8"));
+
+    it("returns expected list of extensions for MIME type without charset", () => {
+        const type = MimeType.from("text/plain");
+        expect(type.extensions).toContain("txt");
     });
 
-    it("creates known MIME type with charset", () => {
-        testValidMimeType("text/plain;charset=utf-8");
+    it("returns expected list of extensions for MIME type without charset", () => {
+        const type = MimeType.from("text/plain;charset=utf-8");
+        expect(type.extensions).toContain("txt");
     });
+
+    it("returns expected main extension for TXT", () => testMainExtension("text/plain", "txt"));
+    it("returns expected main extension for PDF", () => testMainExtension("application/pdf", "pdf"));
+    it("returns expected main extension for JPG", () => testMainExtension("image/jpeg", "jpeg"));
+    it("returns expected main extension for PNG", () => testMainExtension("image/png", "png"));
+    it("returns expected main extension for GIF", () => testMainExtension("image/gif", "gif"));
 });
 
 function testValidMimeType(mimeType: string) {
     const type = MimeType.from(mimeType);
     expect(type.mimeType).toBe(mimeType);
+}
+
+function testMainExtension(mime: string, extension: string) {
+    const type = MimeType.from(mime);
+    expect(type.extensions[0]).toBe(extension);
 }


### PR DESCRIPTION
* `MimeType` class was already relying on `mime-db` which exposes the extensions associated with a given mime type
* The class has now an `extensions` property that can be used to choose the right extension for a file name

logion-network/logion-internal#613