### PR TITLE
Check hash of collection item files.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.15.0-2",
+  "version": "0.15.0-3",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/CollectionItem.ts
+++ b/packages/client/src/CollectionItem.ts
@@ -3,6 +3,7 @@ import { UUID } from "@logion/node-api";
 import { ItemDelivery, LocClient, UploadableCollectionItem, UploadableItemFile } from "./LocClient";
 import { ItemTokenWithRestrictedType } from "./Token";
 import { LogionClassification, SpecificLicense, TermsAndConditionsElement } from "./license";
+import { CheckHashResult } from "./Loc";
 
 export class CollectionItem implements UploadableCollectionItem {
 
@@ -77,6 +78,16 @@ export class CollectionItem implements UploadableCollectionItem {
 
     get specificLicenses(): SpecificLicense[] {
         return this._specificLicenses;
+    }
+
+    getItemFile(hash: string): UploadableItemFile | undefined {
+        return this.clientItem.files.find(file => file.hash === hash);
+    }
+
+    checkHash(hash: string): CheckHashResult {
+        return {
+            collectionItemFile: this.getItemFile(hash)
+        }
     }
 
     async checkCertifiedCopy(hash: string): Promise<CheckCertifiedCopyResult> {

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -1,4 +1,4 @@
-import { UUID, LegalOfficerCase, LocType, VoidInfo } from "@logion/node-api";
+import { UUID, LegalOfficerCase, LocType, VoidInfo, ItemFile } from "@logion/node-api";
 
 import {
     LocRequest,
@@ -223,6 +223,7 @@ export interface CheckHashResult {
     file?: MergedFile;
     metadataItem?: MergedMetadataItem;
     collectionItem?: CollectionItemClass;
+    collectionItemFile?: ItemFile;
 }
 
 export class LocRequestState {

--- a/packages/client/src/Public.ts
+++ b/packages/client/src/Public.ts
@@ -83,19 +83,29 @@ export class PublicLoc {
         return this._data;
     }
 
-    async checkHash(hash: string): Promise<CheckHashResult> {
+    async checkHash(hash: string, itemId?: string): Promise<CheckHashResult> {
         const result = LocRequestState.checkHash(this._data, hash);
         let collectionItem = undefined;
+        let collectionItemFile = undefined;
         if(this._data.locType === "Collection") {
             collectionItem = await getCollectionItem({
                 locClient: this.client,
                 locId: this._data.id,
                 itemId: hash,
             });
+            if (itemId) {
+                const collectionItemToInspect = await getCollectionItem({
+                    locClient: this.client,
+                    locId: this._data.id,
+                    itemId,
+                });
+                collectionItemFile = collectionItemToInspect?.getItemFile(hash);
+            }
         }
         return {
             ...result,
             collectionItem,
+            collectionItemFile
         };
     }
 

--- a/packages/client/test/CollectionItem.spec.ts
+++ b/packages/client/test/CollectionItem.spec.ts
@@ -38,23 +38,38 @@ describe("CollectionItem checkCertifiedCopy", () => {
         thenResultFully(result, CheckResultType.NEGATIVE);
     });
 
-    it("detects that latest copy hash comes from certified copy in unprivleged mode", async () => {
+    it("detects that latest copy hash comes from certified copy in unprivileged mode", async () => {
         const item = given(false);
         const result = await item.checkCertifiedCopy(copyHash);
         thenResultFully(result, CheckResultType.POSITIVE);
     });
 
-    it("detects old copy as non certified in unprivleged mode", async () => {
+    it("detects old copy as non certified in unprivileged mode", async () => {
         const item = given(false);
         const result = await item.checkCertifiedCopy(oldCopyHash);
         thenResultFully(result, CheckResultType.NEGATIVE);
     });
 
-    it("detects non certified copy in unprivleged mode", async () => {
+    it("detects non certified copy in unprivileged mode", async () => {
         const item = given(false);
         const result = await item.checkCertifiedCopy(otherHash);
         thenResultFully(result, CheckResultType.NEGATIVE);
     });
+});
+
+describe("CollectionItem checkHash", () => {
+
+    it("succeeds to check original hash", () => {
+        const item = given(false);
+        const result = item.checkHash(originalHash);
+        expect(result.collectionItemFile?.hash).toEqual(originalHash);
+    })
+
+    it("fails to check copy hash", () => {
+        const item = given(false);
+        const result = item.checkHash(copyHash);
+        expect(result.collectionItemFile).toBeUndefined();
+    })
 });
 
 function given(privileged: boolean, tc?: TermsAndConditionsElement[]): CollectionItem {

--- a/packages/client/test/LocUtils.ts
+++ b/packages/client/test/LocUtils.ts
@@ -12,7 +12,7 @@ import { Option, Bytes } from "@polkadot/types-codec";
 import { DateTime } from "luxon";
 import { Mock } from "moq.ts";
 
-import { LocFile, LocRequest, LocRequestStatus, OffchainCollectionItem } from "../src";
+import { LocFile, LocRequest, LocRequestStatus, OffchainCollectionItem, UploadableItemFile } from "../src";
 import { mockBool, mockCodecWithToHex, mockCodecWithToString, mockCodecWithToUtf8, mockEmptyOption, mockOption, mockVec, REQUESTER } from "./Utils";
 
 export const EXISTING_FILE_HASH = "0xa4d9f9f1a02baae960d1a7c4cedb25940a414ae4c545bf2f14ab24691fec09a5";
@@ -23,6 +23,16 @@ export const EXISTING_FILE: LocFile = {
     nature: "Some nature",
     submitter: REQUESTER,
 };
+
+export const EXISTING_ITEM_FILE_HASH = "0x8443d95fceccd27c0ca8d8c8d6c443ddc787afc234620a5548baf8c7b46aa277";
+
+export const EXISTING_ITEM_FILE: UploadableItemFile = {
+    name: "existing-item-file.txt",
+    hash: EXISTING_ITEM_FILE_HASH,
+    contentType: "text/plain",
+    size: 0n,
+    uploaded: false,
+}
 
 export type LocAndRequest = {
     request: LocRequest,


### PR DESCRIPTION
Collection Item file can be checked via 2 different ways:

* `CollectionItem.checkHash()` - performs the hash detection on all files of the item.
* `Public.checkHash()` - where an optional param `itemId`now also triggers the hash detection on files of the item. Intended usage is to provide a unique method to check all possible matches under LOC and collection item, typically in the certificate.

logion-network/logion-internal#631