### PR TITLE
Send file hash to backend on upload

### DIFF
--- a/packages/client/integration/Loc.ts
+++ b/packages/client/integration/Loc.ts
@@ -79,7 +79,7 @@ export async function requestTransactionLoc(state: State) {
     openLoc = await openLoc.addFile({
         fileName: "test.txt",
         nature: "Some file nature",
-        file: Buffer.from("test"),
+        file: HashOrContent.fromContent(Buffer.from("test")),
     }) as OpenLoc;
     const hash = openLoc.data().files[0].hash;
     expect(hash).toBe("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.16.0-1",
+  "version": "0.16.0-2",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Hash.ts
+++ b/packages/client/src/Hash.ts
@@ -136,7 +136,7 @@ export class HashOrContent {
         } else if(isBuffer(this._content)) {
             const buffer = this._content as Buffer;
             return {
-                hash: await hashBuffer(buffer),
+                hash: hashBuffer(buffer),
                 size: BigInt(buffer.length)
             };
         } else if(typeof this._content === "string") {

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -674,7 +674,7 @@ async function testAddMetadata(editable: EditableRequest) {
 
 async function testAddFile(editable: EditableRequest) {
     let newState = await editable.addFile({
-        file: Buffer.from("test"),
+        file: HashOrContent.fromContent(Buffer.from("test")),
         fileName: "test.txt",
         nature: "Some nature",
     });


### PR DESCRIPTION
* Backend now expects file hashes to be generated client-side so that it can check that received file has the expected content

logion-network/logion-internal#665