### PR TITLE
Add Voter API

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.18.0-4",
+  "version": "0.18.0-5",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -56,6 +56,7 @@ export interface LocData {
     verifiedThirdParty: boolean;
     selectedParties: VerifiedThirdParty[];
     iDenfy?: IdenfyVerificationSession;
+    voteId?: string;
 }
 
 export interface MergedLink extends LocLink, Published {
@@ -519,6 +520,7 @@ export abstract class LocRequestState extends State {
             metadata: request.metadata.map(item => LocRequestState.mergeMetadata(item)),
             files: request.files.map(item => LocRequestState.mergeFile(item)),
             links: request.links.map(item => LocRequestState.mergeLink(item)),
+            voteId: request.voteId ? request.voteId : undefined,
         };
     }
 
@@ -544,6 +546,7 @@ export abstract class LocRequestState extends State {
             verifiedThirdParty: request.verifiedThirdParty,
             selectedParties: request.selectedParties,
             iDenfy: request.iDenfy,
+            voteId: request.voteId ? request.voteId : undefined,
         };
 
         if(data.voidInfo && request.voidInfo) {
@@ -903,5 +906,16 @@ export class VoidedCollectionLoc extends ClosedOrVoidCollectionLoc {
 
     override withLocs(locsState: LocsState): VoidedCollectionLoc {
         return this._withLocs(locsState, VoidedCollectionLoc);
+    }
+}
+
+export class ReadOnlyLocState extends LocRequestState {
+
+    constructor(locSharedState: LocSharedState, request: LocRequest, legalOfficerCase?: LegalOfficerCase) {
+        super(locSharedState, request, legalOfficerCase);
+    }
+
+    withLocs(locsState: LocsState): LocRequestState {
+        return this._withLocs(locsState, ReadOnlyLocState);
     }
 }

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -101,6 +101,7 @@ export interface LocRequest {
     verifiedThirdParty: boolean;
     selectedParties: VerifiedThirdParty[];
     iDenfy?: IdenfyVerificationSession;
+    voteId?: string | null;
 }
 
 export interface IdenfyVerificationSession {

--- a/packages/client/src/LogionClient.ts
+++ b/packages/client/src/LogionClient.ts
@@ -16,6 +16,7 @@ import { LocsState } from "./Loc.js";
 import { PublicApi } from "./Public.js";
 import { FetchAllLocsParams } from "./LocClient.js";
 import { NetworkState } from "./NetworkState.js";
+import { VoterApi } from "./Voter.js";
 
 export class LogionClient {
 
@@ -48,11 +49,14 @@ export class LogionClient {
     constructor(sharedState: SharedState) {
         this.sharedState = sharedState;
         this._public = new PublicApi({ sharedState });
+        this._voter = new VoterApi({ sharedState, logionClient: this });
     }
 
     private sharedState: SharedState;
 
     private _public: PublicApi;
+
+    private _voter: VoterApi;
 
     get config(): LogionClientConfig {
         return this.sharedState.config;
@@ -291,6 +295,11 @@ export class LogionClient {
     get public(): PublicApi {
         this.ensureConnected();
         return this._public;
+    }
+
+    get voter(): VoterApi {
+        this.ensureConnected();
+        return this._voter;
     }
 
     async disconnect() {

--- a/packages/client/src/Voter.ts
+++ b/packages/client/src/Voter.ts
@@ -1,0 +1,72 @@
+import { LegalOfficerCase, UUID } from "@logion/node-api";
+import { LocSharedState, LocsState, ReadOnlyLocState } from "./Loc.js";
+import { AuthenticatedLocClient, LocMultiClient, LocRequest } from "./LocClient.js";
+import { LogionClient } from "./LogionClient.js";
+import { SharedState } from "./SharedClient.js";
+
+export class VoterApi {
+
+    constructor(args: {
+        sharedState: SharedState,
+        logionClient: LogionClient,
+    }) {
+        this.sharedState = args.sharedState;
+        this.logionClient = args.logionClient;
+    }
+
+    private sharedState: SharedState;
+
+    private logionClient: LogionClient;
+
+    async findLocById(locId: UUID): Promise<ReadOnlyLocState | undefined> {
+        const locAndClient = await this.getLocAndClient(locId);
+        if(!locAndClient) {
+            return undefined;
+        }
+        const { loc, locRequest, client } = locAndClient;
+        const legalOfficer = this.sharedState.allLegalOfficers.find(legalOfficer => legalOfficer.address === locRequest.ownerAddress);
+        if(!legalOfficer) {
+            throw new Error(`Unknown legal officer ${locRequest.ownerAddress}`);
+        }
+        const locsState = new LocsState(this.sharedState, {}, this.logionClient, {});
+        const locSharedState: LocSharedState = {
+            ...this.sharedState,
+            legalOfficer,
+            client,
+            locsState,
+        }
+        return new ReadOnlyLocState(locSharedState, locRequest, loc);
+    }
+
+    private async getLocAndClient(locId: UUID): Promise<{ loc: LegalOfficerCase, locRequest: LocRequest, client: AuthenticatedLocClient } | undefined> {
+        const loc = await LocMultiClient.getLoc({
+            locId,
+            api: this.sharedState.nodeApi,
+        });
+        const legalOfficer = this.sharedState.legalOfficers.find(lo => lo.address === loc.owner);
+        if (!legalOfficer) {
+            return undefined;
+        }
+        if (!this.sharedState.currentAddress) {
+            throw new Error("Current address must be set");
+        }
+        const token = this.sharedState.tokens.get(this.sharedState.currentAddress);
+        if (!token) {
+            throw new Error("Client must be authenticated");
+        }
+        const client = new AuthenticatedLocClient({
+            ...this.sharedState,
+            axiosFactory: this.sharedState.axiosFactory,
+            nodeApi: this.sharedState.nodeApi,
+            legalOfficer,
+            currentAddress: this.sharedState.currentAddress,
+            token: token.value,
+        });
+        const locRequest = await client.getLocRequest({ locId });
+        return {
+            loc,
+            locRequest,
+            client,
+        }
+    }
+}

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -30,4 +30,5 @@ export * from './TransactionClient.js';
 export * from './Types.js';
 export * from './Vault.js';
 export * from './VaultClient.js';
+export * from './Voter.js';
 export * from './license/index.js';

--- a/packages/client/test/Voter.spec.ts
+++ b/packages/client/test/Voter.spec.ts
@@ -1,0 +1,77 @@
+import { LogionNodeApi, UUID } from "@logion/node-api";
+import { AxiosInstance, AxiosResponse } from "axios";
+import { DateTime } from "luxon";
+import { Mock } from "moq.ts";
+import {
+    AccountTokens,
+    SharedState,
+    VoterApi,
+    LogionClient,
+    ReadOnlyLocState,
+} from "../src/index.js";
+import {
+    ALICE,
+    buildTestAuthenticatedSharedSate,
+    LEGAL_OFFICERS,
+    LOGION_CLIENT_CONFIG,
+} from "./Utils.js";
+import { TestConfigFactory } from "./TestConfigFactory.js";
+import {
+    buildLoc,
+    buildLocRequest,
+} from "./LocUtils.js";
+
+describe("VoterApi", () => {
+
+    it("finds LOC", async () => {
+        const sharedState = await buildSharedState();
+        const logionClient = new LogionClient(sharedState).useTokens(tokens).withCurrentAddress(ALICE.address);
+        const voterApi = new VoterApi({ sharedState, logionClient });
+
+        const readOnlyState = await voterApi.findLocById(new UUID(LOC_REQUEST.id));
+
+        expect(readOnlyState).toBeDefined();
+        expect(readOnlyState).toBeInstanceOf(ReadOnlyLocState);
+    });
+});
+
+const LOC_REQUEST = buildLocRequest(ALICE.address, "CLOSED", "Identity");
+const LOC = buildLoc(ALICE.address, "CLOSED", "Identity");
+
+let aliceAxiosMock: Mock<AxiosInstance>;
+let nodeApiMock: Mock<LogionNodeApi>;
+
+const currentAddress = ALICE.address;
+const token = "some-token";
+const tokens = new AccountTokens({
+    [ALICE.address]: {
+        value: token,
+        expirationDateTime: DateTime.now().plus({ hours: 1 })
+    }
+});
+
+async function buildSharedState(): Promise<SharedState> {
+    return await buildTestAuthenticatedSharedSate(
+        (factory: TestConfigFactory) => {
+            factory.setupDefaultNetworkState();
+            factory.setupDefaultFormDataFactory();
+            factory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
+
+            const axiosFactoryMock = factory.setupAxiosFactoryMock();
+
+            aliceAxiosMock = new Mock<AxiosInstance>();
+            aliceAxiosMock.setup(instance => instance.get(`/api/loc-request/${ LOC_REQUEST.id }`)).returnsAsync({
+                data: LOC_REQUEST
+            } as AxiosResponse);
+            axiosFactoryMock.setup(instance => instance.buildAxiosInstance(ALICE.node, token))
+                .returns(aliceAxiosMock.object());
+
+            nodeApiMock = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
+            nodeApiMock.setup(instance => instance.query.logionLoc.locMap(new UUID(LOC_REQUEST.id).toHexString()))
+                .returnsAsync(LOC);
+        },
+        currentAddress,
+        LEGAL_OFFICERS,
+        tokens,
+    );
+}


### PR DESCRIPTION
* Voter API opens access to any LOC, provided it has been submitted for a vote and the voter has been invited to vote (to be handled backend-side).
* The LOC is returned in the form of a read-only LOC state, enabling to re-use client side code handling LOC states.

logion-network/logion-internal#714