### PR TITLE
Rename collection item endpoint.

### DIFF
--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -427,7 +427,7 @@ export abstract class LocClient {
 
     private async getOffchainItem(parameters: { locId: UUID, itemId: string }): Promise<OffchainCollectionItem> {
         const { locId, itemId } = parameters;
-        const response = await this.backend().get(`/api/collection/${ locId.toString() }/${ itemId }`);
+        const response = await this.backend().get(`/api/collection/${ locId.toString() }/items/${ itemId }`);
         return response.data;
     }
 

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -529,7 +529,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
             aliceAxiosMock.setup(instance => instance.post(`/api/loc-request/sof`, It.IsAny())).returnsAsync({
                 data: ALICE_REQUESTED_SOF_REQUEST
             } as AxiosResponse);
-            aliceAxiosMock.setup(instance => instance.get(`/api/collection/${ ALICE_CLOSED_COLLECTION_LOC.request.id }/${ EXISTING_ITEM_ID }`)).returnsAsync({
+            aliceAxiosMock.setup(instance => instance.get(`/api/collection/${ ALICE_CLOSED_COLLECTION_LOC.request.id }/items/${ EXISTING_ITEM_ID }`)).returnsAsync({
                 data: OFFCHAIN_COLLECTION_ITEM
             } as AxiosResponse);
             axiosFactoryMock.setup(instance => instance.buildAxiosInstance(ALICE.node, token))
@@ -554,7 +554,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                     data: request
                 } as AxiosResponse);
             })
-            bobAxiosMock.setup(instance => instance.get(`/api/collection/${ BOB_VOID_COLLECTION_LOC.request.id }/${ EXISTING_ITEM_ID }`)).returnsAsync({
+            bobAxiosMock.setup(instance => instance.get(`/api/collection/${ BOB_VOID_COLLECTION_LOC.request.id }/items/${ EXISTING_ITEM_ID }`)).returnsAsync({
                 data: OFFCHAIN_COLLECTION_ITEM
             } as AxiosResponse);
             axiosFactoryMock.setup(instance => instance.buildAxiosInstance(BOB.node, token))

--- a/packages/client/test/Public.spec.ts
+++ b/packages/client/test/Public.spec.ts
@@ -160,7 +160,7 @@ async function buildSharedState(): Promise<SharedState> {
             aliceAxiosMock.setup(instance => instance.get(`/api/loc-request/${ LOC_REQUEST.id }/public`)).returnsAsync({
                 data: LOC_REQUEST
             } as AxiosResponse);
-            aliceAxiosMock.setup(instance => instance.get(`/api/collection/${ LOC_REQUEST.id }/${ EXISTING_ITEM_ID }`)).returnsAsync({
+            aliceAxiosMock.setup(instance => instance.get(`/api/collection/${ LOC_REQUEST.id }/items/${ EXISTING_ITEM_ID }`)).returnsAsync({
                 data: OFFCHAIN_COLLECTION_ITEM
             } as AxiosResponse);
             axiosFactoryMock.setup(instance => instance.buildAxiosInstance(ALICE.node))


### PR DESCRIPTION
Endpoint to access collection item is changed to `/:collectionLocId/items/:itemId`. See [this PR on backend](https://github.com/logion-network/logion-backend-ts/pull/215).