### PR TITLE
Add getCurrentState to State

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.20.0-6",
+  "version": "0.20.0-7",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -682,7 +682,7 @@ export class DraftRequest extends EditableRequest {
     async cancel(): Promise<LocsState> {
         this.ensureCurrent();
         await this.locSharedState.client.cancel(this.locId);
-        this.discard();
+        this.discard(undefined);
         return this.locSharedState.locsState.refreshWithout(this.locId);
     }
 
@@ -708,7 +708,7 @@ export class RejectedRequest extends LocRequestState {
     async cancel(): Promise<LocsState> {
         this.ensureCurrent();
         await this.locSharedState.client.cancel(this.locId);
-        this.discard();
+        this.discard(undefined);
         return this.locSharedState.locsState.refreshWithout(this.locId);
     }
 

--- a/packages/client/test/State.spec.ts
+++ b/packages/client/test/State.spec.ts
@@ -1,0 +1,38 @@
+import { State } from "../src/index.js";
+
+describe("State", () => {
+
+    it("can be discarded", () => {
+        const first = new FirstState();
+        const intermediate = new IntermediateState();
+        first.discardWith(intermediate);
+        const current = new CurrentState();
+        intermediate.discardWith(current);
+
+        expect(first.discarded).toBe(true);
+        expect(intermediate.discarded).toBe(true);
+        expect(current.discarded).toBe(false);
+
+        expect(first.getCurrentState()).toBe(current);
+        expect(intermediate.getCurrentState()).toBe(current);
+        expect(current.getCurrentState()).toBe(current);
+    });
+});
+
+class FirstState extends State {
+
+    discardWith(nextState: IntermediateState | undefined) {
+        this.discard(nextState);
+    }
+}
+
+class IntermediateState extends State {
+
+    discardWith(nextState: CurrentState | undefined) {
+        this.discard(nextState);
+    }
+}
+
+class CurrentState extends State {
+
+}


### PR DESCRIPTION
* This enables client code to always have access to the current state, even in case if concurrent execution.

logion-network/logion-internal#693