### PR TITLE
Add check for compatibility between token type and network type.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.21.1-3",
+  "version": "0.21.1-4",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Token.ts
+++ b/packages/client/src/Token.ts
@@ -20,7 +20,9 @@ export type TokenType =
     | 'polygon_erc20'
     | 'polygon_mumbai_erc20'
     | 'owner'
-;
+    ;
+
+export type NetworkType = 'ETHEREUM' | 'POLKADOT';
 
 export function isTokenType(type: string): type is TokenType {
     return (
@@ -39,6 +41,18 @@ export function isTokenType(type: string): type is TokenType {
         || type === 'polygon_mumbai_erc20'
         || type === 'owner'
     );
+}
+
+export function isTokenCompatibleWith(type: TokenType, networkType: NetworkType): boolean {
+    if (networkType === 'ETHEREUM') {
+        return type.startsWith("ethereum")
+            || type.startsWith("goerli")
+            || type.startsWith("polygon")
+            || type === "owner"
+    } else {
+        return type === "singular_kusama"
+            || type === "owner"
+    }
 }
 
 export interface TokenValidationResult {

--- a/packages/client/test/Token.spec.ts
+++ b/packages/client/test/Token.spec.ts
@@ -1,4 +1,10 @@
-import { ItemTokenWithRestrictedType, TokenType, validateToken, isTokenType } from "../src/index.js";
+import {
+    ItemTokenWithRestrictedType,
+    TokenType,
+    validateToken,
+    isTokenType,
+    isTokenCompatibleWith, NetworkType
+} from "../src/index.js";
 
 const ercNonFungibleTypes: TokenType[] = [
     "ethereum_erc721",
@@ -11,7 +17,7 @@ const ercNonFungibleTypes: TokenType[] = [
     "polygon_mumbai_erc1155"
 ];
 
-const ercFongibleTypes: TokenType[] = [
+const ercFungibleTypes: TokenType[] = [
     "ethereum_erc20",
     "goerli_erc20",
     "polygon_erc20",
@@ -25,7 +31,7 @@ const otherTypes: TokenType[] = [
 
 const allTypes: TokenType[] = [
     ...ercNonFungibleTypes,
-    ...ercFongibleTypes,
+    ...ercFungibleTypes,
     ...otherTypes,
 ];
 
@@ -45,14 +51,31 @@ describe("validateToken", () => {
         it(`invalidates ${ type } token with missing contract field`, () => testErcInvalidIdMissingContract(type));
         it(`invalidates ${ type } token with wrongly typed contract field`, () => testErcInvalidIdContractIsNotString(type));
         it(`invalidates ${ type } token with wrongly typed id field`, () => testErcInvalidIdIdIsNotString(type));
+        it(`${ type } is ETHEREUM-compatible`, () => testIsTokenCompatibleWith(type, 'ETHEREUM'))
+        it(`${ type } is NOT POLKADOT-compatible`, () => testIsTokenNotCompatibleWith(type, 'POLKADOT'))
     }
 
-    for (const type of ercFongibleTypes) {
+    for (const type of ercFungibleTypes) {
         it(`validates valid ${ type } token`, () => testFungibleErcValidToken(type));
         it(`invalidates ${ type } token with non-JSON id`, () => testErcInvalidIdType(type));
         it(`invalidates ${ type } token with missing contract field`, () => testErcInvalidIdMissingContract(type));
         it(`invalidates ${ type } token with wrongly typed contract field`, () => testErcInvalidIdContractIsNotString(type));
+        it(`checks that ${ type } is ETHEREUM-compatible`, () => testIsTokenCompatibleWith(type, 'ETHEREUM'))
+        it(`checks that ${ type } is NOT POLKADOT-compatible`, () => testIsTokenNotCompatibleWith(type, 'POLKADOT'))
     }
+
+    it(`checks that owner is both POLKADOT- and ETHEREUM-compatible`, () => {
+        testIsTokenCompatibleWith('owner', 'POLKADOT');
+        testIsTokenCompatibleWith('owner', 'ETHEREUM');
+    });
+
+    it(`checks that singular_kusama is NOT ETHEREUM-compatible`, () =>
+        testIsTokenNotCompatibleWith('singular_kusama', 'ETHEREUM')
+    );
+
+    it(`checks that singular_kusama is POLKADOT-compatible`, () =>
+        testIsTokenCompatibleWith('singular_kusama', 'POLKADOT')
+    );
 
     it("validates valid owner token", () => {
         testValid({
@@ -153,6 +176,16 @@ function testFungibleErcValidToken(type: TokenType) {
         type,
         id: '{"contract":"0x765df6da33c1ec1f83be42db171d7ee334a46df5"}'
     });
+}
+
+function testIsTokenCompatibleWith(type: TokenType, networkType: NetworkType) {
+    const result = isTokenCompatibleWith(type, networkType)
+    expect(result).toBeTrue();
+}
+
+function testIsTokenNotCompatibleWith(type: TokenType, networkType: NetworkType) {
+    const result = isTokenCompatibleWith(type, networkType)
+    expect(result).toBeFalse();
 }
 
 describe("isTokenType", () => {


### PR DESCRIPTION
* Add the possibility to check if a given token type (`ethereum_erc20`, `owner`, etc.) is compatible with a given Network type. Currently only 2 networks are supported: `ETHEREUM` and `POLKADOT`.
* Intended use is for front-end app to determine which signing tool to present to the user.

logion-network/logion-internal#793