### PR TITLE
Add fees estimator

### DIFF
--- a/packages/client/integration/Fees.ts
+++ b/packages/client/integration/Fees.ts
@@ -1,0 +1,10 @@
+import { ALICE } from "../test/Utils.js";
+import { State, REQUESTER_ADDRESS } from "./Utils.js";
+
+export async function fees(state: State) {
+    const client = state.client;
+    const api = client.nodeApi;
+    const submittable = api.tx.balances.transfer(ALICE.address, "10000000");
+    const fees = await client.public.fees.estimateWithoutStorage({ origin: REQUESTER_ADDRESS, submittable });
+    expect(fees.totalFee).toBe(273154144n);
+}

--- a/packages/client/integration/Main.spec.ts
+++ b/packages/client/integration/Main.spec.ts
@@ -6,6 +6,7 @@ import { recoverLostAccount, requestRecoveryAndCancel } from "./Recovery.js";
 import { requestTransactionLoc, collectionLoc, collectionLocWithUpload, identityLoc } from "./Loc.js";
 import { verifiedThirdParty } from "./VerifiedThirdParty.js";
 import { tokensRecords } from "./TokensRecord.js";
+import { fees } from "./Fees.js";
 
 describe("Logion SDK", () => {
 
@@ -15,6 +16,10 @@ describe("Logion SDK", () => {
 
     beforeAll(async () => {
         state = await setupInitialState();
+    });
+
+    it("estimates fees", async () => {
+        await fees(state);
     });
 
     it("transfers", async () => {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.22.0-9",
+  "version": "0.22.0-10",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/FeesEstimator.ts
+++ b/packages/client/src/FeesEstimator.ts
@@ -1,0 +1,61 @@
+import { LogionNodeApi, UUID, addFile } from "@logion/node-api";
+import { SubmittableExtrinsic } from "@polkadot/api/promise/types";
+
+export class Fees {
+
+    constructor(inclusionFee: bigint, storageFee?: bigint) {
+        this.inclusionFee = inclusionFee;
+        this.storageFee = storageFee;
+    }
+
+    readonly inclusionFee: bigint;
+    readonly storageFee?: bigint;
+
+    get totalFee(): bigint {
+        return this.inclusionFee + (this.storageFee || 0n);
+    }
+}
+
+export class FeesEstimator {
+
+    constructor(api: LogionNodeApi) {
+        this.api = api;
+    }
+
+    private api: LogionNodeApi;
+
+    async estimateAddFile(args: {
+        locId: UUID,
+        hash: string,
+        nature: string,
+        submitter: string,
+        size: bigint,
+        origin: string,
+    }): Promise<Fees> {
+        const submittable = addFile({
+            api: this.api,
+            hash: args.hash,
+            locId: args.locId,
+            nature: args.nature,
+            size: args.size,
+            submitter: args.submitter,
+        });
+        const inclusionFee = await this.estimateInclusionFee(args.origin, submittable);
+        const storageFee = BigInt(0);
+        return new Fees(inclusionFee, storageFee);
+    }
+
+    private async estimateInclusionFee(origin: string, submittable: SubmittableExtrinsic): Promise<bigint> {
+        const dispatchInfo = await submittable.paymentInfo(origin);
+        const partialFee = dispatchInfo.partialFee;
+        return BigInt(partialFee.toString());
+    }
+
+    async estimateWithoutStorage(args: {
+        origin: string,
+        submittable: SubmittableExtrinsic,
+    }): Promise<Fees> {
+        const inclusionFee = await this.estimateInclusionFee(args.origin, args.submittable);
+        return new Fees(inclusionFee);
+    }
+}

--- a/packages/client/src/Public.ts
+++ b/packages/client/src/Public.ts
@@ -2,6 +2,7 @@ import { LegalOfficerCase, UUID } from "@logion/node-api";
 
 import { CollectionItem } from "./CollectionItem.js";
 import { CheckCertifiedCopyResult, CheckResultType } from "./Deliveries.js";
+import { FeesEstimator } from "./FeesEstimator.js";
 import { CheckHashResult, getCollectionItem, getTokensRecords, LocData, LocRequestState } from "./Loc.js";
 import {
     EMPTY_LOC_ISSUERS,
@@ -20,9 +21,12 @@ export class PublicApi {
         sharedState: SharedState
     }) {
         this.sharedState = args.sharedState;
+        this.fees = new FeesEstimator(args.sharedState.nodeApi);
     }
 
     private sharedState: SharedState;
+
+    readonly fees: FeesEstimator;
 
     async findLocById(params: FetchParameters): Promise<PublicLoc | undefined> {
         const locAndClient = await this.getLocAndClient(params);
@@ -87,7 +91,6 @@ export class PublicApi {
             jwtToken,
         })
     }
-
 }
 
 export class PublicLoc {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -34,3 +34,4 @@ export * from './Voter.js';
 export * from './license/index.js';
 export * from './Deliveries.js';
 export * from './TokensRecord.js';
+export * from './FeesEstimator.js';

--- a/packages/client/test/Public.spec.ts
+++ b/packages/client/test/Public.spec.ts
@@ -1,6 +1,8 @@
 import { LogionNodeApi, UUID } from "@logion/node-api";
 import { AxiosInstance, AxiosResponse } from "axios";
 import { It, Mock } from "moq.ts";
+import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
+import type { RuntimeDispatchInfo } from '@polkadot/types/interfaces';
 
 import {
     AccountTokens,
@@ -10,13 +12,16 @@ import {
     PublicLocClient,
     SharedState,
     PublicApi,
-    PublicLoc
+    PublicLoc,
+    hashString,
+    FeesEstimator,
 } from "../src/index.js";
 import {
     ALICE,
     buildTestAuthenticatedSharedSate,
     LEGAL_OFFICERS,
     LOGION_CLIENT_CONFIG,
+    mockCodecWithToString,
     mockEmptyOption
 } from "./Utils.js";
 import { TestConfigFactory } from "./TestConfigFactory.js";
@@ -52,6 +57,15 @@ describe("PublicApi", () => {
 
         expect(item).toBeDefined();
         expect(item).toBeInstanceOf(CollectionItem);
+    });
+
+    it("provides fees estimator", async () => {
+        const sharedState = await buildSharedState();
+        const publicApi = new PublicApi({ sharedState });
+
+        const estimator = publicApi.fees;
+
+        expect(estimator).toBeInstanceOf(FeesEstimator);
     });
 });
 
@@ -183,3 +197,52 @@ async function buildSharedState(): Promise<SharedState> {
         new AccountTokens({}),
     );
 }
+
+describe("FeesEstimator", () => {
+
+    it("estimates fees on file add", async () => {
+        nodeApiMock = new Mock<LogionNodeApi>();
+        const hexId = new UUID(LOC_REQUEST.id).toHexString();
+        const dispatchInfo = new Mock<RuntimeDispatchInfo>();
+        const expectedInclusionFee = 42n;
+        dispatchInfo.setup(instance => instance.partialFee).returns(mockCodecWithToString(expectedInclusionFee.toString()));
+        const submittable = new Mock<SubmittableExtrinsic>();
+        submittable.setup(instance => instance.paymentInfo(ALICE.address)).returns(Promise.resolve(dispatchInfo.object()));
+
+        nodeApiMock.setup(instance => instance.tx.logionLoc.addFile(hexId, It.IsAny()))
+            .returns(submittable.object());
+        const estimator = new FeesEstimator(nodeApiMock.object());
+
+        const fees = await estimator.estimateAddFile({
+            locId: new UUID(LOC_REQUEST.id),
+            hash: hashString("test"),
+            nature: "Some nature",
+            submitter: ALICE.address,
+            size: 42n,
+            origin: ALICE.address,
+        });
+
+        expect(fees.inclusionFee).toBe(expectedInclusionFee);
+        expect(fees.storageFee).toBe(0n);
+        expect(fees.totalFee).toBe(expectedInclusionFee);
+    });
+
+    it("estimates fees without storage", async () => {
+        nodeApiMock = new Mock<LogionNodeApi>();
+        const dispatchInfo = new Mock<RuntimeDispatchInfo>();
+        const expectedInclusionFee = 42n;
+        dispatchInfo.setup(instance => instance.partialFee).returns(mockCodecWithToString(expectedInclusionFee.toString()));
+        const submittable = new Mock<SubmittableExtrinsic>();
+        submittable.setup(instance => instance.paymentInfo(ALICE.address)).returns(Promise.resolve(dispatchInfo.object()));
+        const estimator = new FeesEstimator(nodeApiMock.object());
+
+        const fees = await estimator.estimateWithoutStorage({
+            origin: ALICE.address,
+            submittable: submittable.object(),
+        });
+
+        expect(fees.inclusionFee).toBe(expectedInclusionFee);
+        expect(fees.storageFee).toBeUndefined();
+        expect(fees.totalFee).toBe(expectedInclusionFee);
+    });
+});


### PR DESCRIPTION
* Adds fees estimator to public API.
* Storage fees are currently set to 0 (waiting for availability in node-api).

logion-network/logion-internal#831