### PR TITLE
Enable authentication with any address type

### DIFF
--- a/packages/client/integration/Balance.ts
+++ b/packages/client/integration/Balance.ts
@@ -6,10 +6,10 @@ import { BalanceState } from "../src/Balance.js";
 import { waitFor } from "../src/Polling.js";
 
 export async function transfers(state: State) {
-    const { client, signer } = state;
+    const { client, signer, aliceAccount, requesterAccount } = state;
 
     // Alice transfers to user.
-    const aliceClient = client.withCurrentAddress(ALICE.address)
+    const aliceClient = client.withCurrentAddress(aliceAccount)
     let aliceState = await aliceClient.balanceState();
 
     checkBalance(aliceState, "100.00k");
@@ -29,7 +29,7 @@ export async function transfers(state: State) {
     expect(aliceState.transactions[0].transferValue).toBe(new PrefixedNumber("5", KILO).convertTo(LGNT_SMALLEST_UNIT).coefficient.unnormalize().toString());
 
     // User transfers to Alice.
-    const userClient = client.withCurrentAddress(REQUESTER_ADDRESS)
+    const userClient = client.withCurrentAddress(requesterAccount)
     let userState = await userClient.balanceState();
 
     checkBalance(userState, "5.00k");

--- a/packages/client/integration/Fees.ts
+++ b/packages/client/integration/Fees.ts
@@ -6,5 +6,5 @@ export async function fees(state: State) {
     const api = client.nodeApi;
     const submittable = api.tx.balances.transfer(ALICE.address, "10000000");
     const fees = await client.public.fees.estimateWithoutStorage({ origin: REQUESTER_ADDRESS, submittable });
-    expect(fees.totalFee).toBe(273154144n);
+    expect(fees.totalFee).toBe(2629491440000000n);
 }

--- a/packages/client/integration/Loc.ts
+++ b/packages/client/integration/Loc.ts
@@ -17,12 +17,9 @@ import {
 
 import { State, TEST_LOGION_CLIENT_CONFIG, NEW_ADDRESS, initRequesterBalance, LegalOfficerWorker } from "./Utils.js";
 
-const USER_ADDRESS = NEW_ADDRESS;
-
 export async function requestTransactionLoc(state: State) {
-
-    const { alice } = state;
-    const client = state.client.withCurrentAddress(USER_ADDRESS);
+    const { alice, newAccount } = state;
+    const client = state.client.withCurrentAddress(newAccount);
     let locsState = await client.locsState();
 
     const legalOfficer = new LegalOfficerWorker(alice, state);
@@ -61,7 +58,7 @@ export async function requestTransactionLoc(state: State) {
     expect(draftRequest).toBeInstanceOf(DraftRequest);
     pendingRequest = await draftRequest.submit();
 
-    await legalOfficer.openTransactionLoc(pendingRequest.locId, USER_ADDRESS);
+    await legalOfficer.openTransactionLoc(pendingRequest.locId, newAccount.address);
 
     let openLoc = await pendingRequest.refresh() as OpenLoc;
     expect(openLoc).toBeInstanceOf(OpenLoc)
@@ -96,13 +93,13 @@ function checkData(data: LocData, locRequestStatus: LocRequestStatus) {
 
 export async function collectionLoc(state: State) {
 
-    const { alice } = state;
-    const client = state.client.withCurrentAddress(USER_ADDRESS);
+    const { alice, newAccount } = state;
+    const client = state.client.withCurrentAddress(newAccount);
     let locsState = await client.locsState();
 
     const legalOfficer = new LegalOfficerWorker(alice, state);
 
-    await initRequesterBalance(TEST_LOGION_CLIENT_CONFIG, state.signer, USER_ADDRESS);
+    await initRequesterBalance(TEST_LOGION_CLIENT_CONFIG, state.signer, newAccount.address);
 
     const pendingRequest = await locsState.requestCollectionLoc({
         legalOfficer: client.getLegalOfficer(alice.address),
@@ -114,7 +111,7 @@ export async function collectionLoc(state: State) {
     expect(locsState.pendingRequests["Collection"][0].data().status).toBe("REQUESTED");
 
     const locId = pendingRequest.locId;
-    await legalOfficer.openCollectionLoc(locId, USER_ADDRESS, false);
+    await legalOfficer.openCollectionLoc(locId, newAccount.address, false);
 
     let openLoc = await pendingRequest.refresh() as OpenLoc;
     await legalOfficer.closeLoc(locId);
@@ -147,13 +144,13 @@ export async function collectionLoc(state: State) {
 
 export async function collectionLocWithUpload(state: State) {
 
-    const { alice } = state;
-    const client = state.client.withCurrentAddress(USER_ADDRESS);
+    const { alice, newAccount } = state;
+    const client = state.client.withCurrentAddress(newAccount);
     let locsState = await client.locsState();
 
     const legalOfficer = new LegalOfficerWorker(alice, state);
 
-    await initRequesterBalance(TEST_LOGION_CLIENT_CONFIG, state.signer, USER_ADDRESS);
+    await initRequesterBalance(TEST_LOGION_CLIENT_CONFIG, state.signer, newAccount.address);
 
     const logionClassificationLocRequest = await locsState.requestTransactionLoc({
         legalOfficer: client.getLegalOfficer(alice.address),
@@ -161,14 +158,14 @@ export async function collectionLocWithUpload(state: State) {
         draft: false,
     });
     locsState = logionClassificationLocRequest.locsState();
-    await legalOfficer.createValidTermsAndConditionsLoc(logionClassificationLocRequest.locId, USER_ADDRESS);
+    await legalOfficer.createValidTermsAndConditionsLoc(logionClassificationLocRequest.locId, newAccount.address);
     const creativeCommonsLocRequest = await locsState.requestTransactionLoc({
         legalOfficer: client.getLegalOfficer(alice.address),
         description: "This is the LOC acting usage of CreativeCommons on logion",
         draft: false,
     });
     locsState = creativeCommonsLocRequest.locsState();
-    await legalOfficer.createValidTermsAndConditionsLoc(creativeCommonsLocRequest.locId, USER_ADDRESS);
+    await legalOfficer.createValidTermsAndConditionsLoc(creativeCommonsLocRequest.locId, newAccount.address);
 
     const pendingRequest = await locsState.requestCollectionLoc({
         legalOfficer: client.getLegalOfficer(alice.address),
@@ -176,7 +173,7 @@ export async function collectionLocWithUpload(state: State) {
         draft: false,
     });
 
-    await legalOfficer.openCollectionLoc(pendingRequest.locId, USER_ADDRESS, true);
+    await legalOfficer.openCollectionLoc(pendingRequest.locId, newAccount.address, true);
 
     let openLoc = await pendingRequest.refresh() as OpenLoc;
     await legalOfficer.closeLoc(openLoc.locId);
@@ -188,7 +185,7 @@ export async function collectionLocWithUpload(state: State) {
     const firstFileHash = hashString(firstFileContent);
     const firstItemToken: ItemTokenWithRestrictedType = {
         type: "owner",
-        id: USER_ADDRESS,
+        id: newAccount.address,
     };
     closedLoc = await closedLoc.addCollectionItem({
         itemId: firstItemId,
@@ -280,9 +277,9 @@ export async function collectionLocWithUpload(state: State) {
 
 export async function identityLoc(state: State) {
 
-    const { alice } = state;
+    const { alice, newAccount } = state;
     const legalOfficer = new LegalOfficerWorker(alice, state);
-    const client = state.client.withCurrentAddress(USER_ADDRESS);
+    const client = state.client.withCurrentAddress(newAccount);
     let locsState = await client.locsState();
 
     const pendingRequest = await locsState.requestIdentityLoc({
@@ -307,5 +304,5 @@ export async function identityLoc(state: State) {
     locsState = pendingRequest.locsState();
     expect(locsState.pendingRequests["Identity"][0].data().status).toBe("REQUESTED");
 
-    await legalOfficer.createValidIdentityLoc(pendingRequest.locId, USER_ADDRESS);
+    await legalOfficer.createValidIdentityLoc(pendingRequest.locId, newAccount.address);
 }

--- a/packages/client/integration/Recovery.ts
+++ b/packages/client/integration/Recovery.ts
@@ -85,28 +85,32 @@ async function requestRecovery(state: State): Promise<PendingProtection> {
 
     const authenticatedClient = client.withCurrentAddress(NEW_ADDRESS)
 
-    const noProtection = await authenticatedClient.protectionState() as NoProtection;
-
-    console.log("Requesting recovery")
-    return await noProtection.requestRecovery({
-        recoveredAddress: REQUESTER_ADDRESS,
-        signer,
-        legalOfficer1: authenticatedClient.getLegalOfficer(alice.address),
-        legalOfficer2: authenticatedClient.getLegalOfficer(charlie.address),
-        userIdentity: {
-            email: "john.doe@invalid.domain",
-            firstName: "John",
-            lastName: "Doe",
-            phoneNumber: "+1234",
-        },
-        postalAddress: {
-            city: "",
-            country: "",
-            line1: "",
-            line2: "",
-            postalCode: "",
-        }
-    });
+    const current = await authenticatedClient.protectionState();
+    expect(current).toBeInstanceOf(NoProtection);
+    if(current instanceof NoProtection) {
+        console.log("Requesting recovery")
+        return await current.requestRecovery({
+            recoveredAddress: REQUESTER_ADDRESS,
+            signer,
+            legalOfficer1: authenticatedClient.getLegalOfficer(alice.address),
+            legalOfficer2: authenticatedClient.getLegalOfficer(charlie.address),
+            userIdentity: {
+                email: "john.doe@invalid.domain",
+                firstName: "John",
+                lastName: "Doe",
+                phoneNumber: "+1234",
+            },
+            postalAddress: {
+                city: "",
+                country: "",
+                line1: "",
+                line2: "",
+                postalCode: "",
+            }
+        });
+    } else {
+        throw new Error("Unexpected state, aborting");
+    }
 }
 
 async function acceptRequestAndVouch(

--- a/packages/client/integration/Recovery.ts
+++ b/packages/client/integration/Recovery.ts
@@ -1,4 +1,4 @@
-import { buildApi } from "@logion/node-api";
+import { ValidAccountId, buildApi } from "@logion/node-api";
 
 import {
     AcceptedProtection,
@@ -16,13 +16,13 @@ import { aliceAcceptsTransfer } from "./Vault.js";
 import { initRequesterBalance, NEW_ADDRESS, REQUESTER_ADDRESS, State } from "./Utils.js";
 
 export async function requestRecoveryAndCancel(state: State) {
-    const { client, signer, alice, charlie } = state;
+    const { client, signer, alice, aliceAccount, charlie, charlieAccount } = state;
 
     const pending = await requestRecovery(state) as PendingProtection;
 
     console.log("LO's - Alice and Bob Rejecting")
-    await rejectRequest(client, signer, charlie, NEW_ADDRESS, "Your protection request is not complete");
-    await rejectRequest(client, signer, alice, NEW_ADDRESS, "Some info is missing");
+    await rejectRequest(client, signer, charlie, charlieAccount, NEW_ADDRESS, "Your protection request is not complete");
+    await rejectRequest(client, signer, alice, aliceAccount, NEW_ADDRESS, "Some info is missing");
 
     const rejected = await pending.refresh() as RejectedProtection;
 
@@ -31,20 +31,20 @@ export async function requestRecoveryAndCancel(state: State) {
 }
 
 export async function recoverLostAccount(state: State) {
-    const { client, signer, alice, charlie } = state;
+    const { client, signer, alice, aliceAccount, charlie, charlieAccount } = state;
 
     const requested = await requestRecovery(state);
 
     console.log("LO's - Alice Rejecting")
-    await rejectRequest(client, signer, alice, NEW_ADDRESS, "for some reason");
+    await rejectRequest(client, signer, alice, aliceAccount, NEW_ADDRESS, "for some reason");
 
     console.log("User resubmitting to Alice");
     const rejected = await requested.refresh() as RejectedProtection;
     const pending = await rejected.resubmit(alice);
 
     console.log("LO's - Accepting and vouching")
-    await acceptRequestAndVouch(client.config, client, signer, alice, REQUESTER_ADDRESS, NEW_ADDRESS);
-    await acceptRequestAndVouch(client.config, client, signer, charlie, REQUESTER_ADDRESS, NEW_ADDRESS);
+    await acceptRequestAndVouch(client.config, client, signer, alice, aliceAccount, REQUESTER_ADDRESS, NEW_ADDRESS);
+    await acceptRequestAndVouch(client.config, client, signer, charlie, charlieAccount, REQUESTER_ADDRESS, NEW_ADDRESS);
 
     const accepted = (await pending.refresh()) as AcceptedProtection;
 
@@ -79,11 +79,11 @@ export async function recoverLostAccount(state: State) {
 }
 
 async function requestRecovery(state: State): Promise<PendingProtection> {
-    const { client, signer, alice, charlie } = state;
+    const { client, signer, alice, charlie, newAccount } = state;
 
     await initRequesterBalance(client.config, signer, NEW_ADDRESS);
 
-    const authenticatedClient = client.withCurrentAddress(NEW_ADDRESS)
+    const authenticatedClient = client.withCurrentAddress(newAccount);
 
     const current = await authenticatedClient.protectionState();
     expect(current).toBeInstanceOf(NoProtection);
@@ -118,10 +118,11 @@ async function acceptRequestAndVouch(
     client: LogionClient,
     signer: FullSigner,
     legalOfficer: LegalOfficer,
+    legalOfficerAccount: ValidAccountId,
     lostAddress: string,
     requesterAddress: string,
 ) {
-    await acceptRequest(config, client, signer, legalOfficer, requesterAddress)
+    await acceptRequest(config, client, signer, legalOfficer, legalOfficerAccount, requesterAddress)
     await vouchRecovery(config, signer, legalOfficer, lostAddress, requesterAddress)
 }
 

--- a/packages/client/integration/TokensRecord.ts
+++ b/packages/client/integration/TokensRecord.ts
@@ -2,10 +2,10 @@ import { ClosedCollectionLoc, HashOrContent, hashString, ItemFileWithContent, Lo
 import { initRequesterBalance, LegalOfficerWorker, NEW_ADDRESS, State, TEST_LOGION_CLIENT_CONFIG, VTP_ADDRESS } from "./Utils.js";
 
 export async function tokensRecords(state: State) {
-    const { alice } = state;
+    const { alice, newAccount, vtpAccount } = state;
     const legalOfficer = new LegalOfficerWorker(alice, state);
 
-    const userClient = state.client.withCurrentAddress(NEW_ADDRESS);
+    const userClient = state.client.withCurrentAddress(newAccount);
     let collectionLoc: LocRequestState = await (await userClient.locsState()).requestCollectionLoc({
         legalOfficer: userClient.getLegalOfficer(alice.address),
         description: "Some LOC with records",
@@ -18,7 +18,7 @@ export async function tokensRecords(state: State) {
 
     await initRequesterBalance(TEST_LOGION_CLIENT_CONFIG, state.signer, VTP_ADDRESS);
 
-    const vtpClient = state.client.withCurrentAddress(VTP_ADDRESS);
+    const vtpClient = state.client.withCurrentAddress(vtpAccount);
     let closedcollectionLoc = (await vtpClient.locsState()).findById(collectionLocId) as ClosedCollectionLoc;
 
     const recordId = hashString("record-id");

--- a/packages/client/integration/Utils.ts
+++ b/packages/client/integration/Utils.ts
@@ -1,4 +1,4 @@
-import { buildApi, UUID, Currency, Numbers } from "@logion/node-api";
+import { buildApi, UUID, Currency, Numbers, AnyAccountId, validPolkadotAccountId, ValidAccountId } from "@logion/node-api";
 import { Keyring } from "@polkadot/api";
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import FormData from "form-data";
@@ -58,6 +58,12 @@ export interface State {
     alice: LegalOfficer;
     bob: LegalOfficer;
     charlie: LegalOfficer;
+    requesterAccount: ValidAccountId,
+    newAccount: ValidAccountId,
+    aliceAccount: ValidAccountId,
+    bobAccount: ValidAccountId,
+    charlieAccount: ValidAccountId,
+    vtpAccount: ValidAccountId,
 }
 
 export async function setupInitialState(): Promise<State> {
@@ -70,13 +76,19 @@ export async function setupInitialState(): Promise<State> {
         CHARLIE_SECRET_SEED,
         VTP_SECRET_SEED,
     ]);
+    const requesterAccount = validPolkadotAccountId(anonymousClient.nodeApi, REQUESTER_ADDRESS);
+    const newAccount = validPolkadotAccountId(anonymousClient.nodeApi, NEW_ADDRESS);
+    const aliceAccount = validPolkadotAccountId(anonymousClient.nodeApi, ALICE.address);
+    const bobAccount = validPolkadotAccountId(anonymousClient.nodeApi, BOB.address);
+    const charlieAccount = validPolkadotAccountId(anonymousClient.nodeApi, CHARLIE.address);
+    const vtpAccount = validPolkadotAccountId(anonymousClient.nodeApi, VTP_ADDRESS);
     const client = await anonymousClient.authenticate([
-        REQUESTER_ADDRESS,
-        NEW_ADDRESS,
-        ALICE.address,
-        BOB.address,
-        CHARLIE.address,
-        VTP_ADDRESS,
+        requesterAccount,
+        newAccount,
+        aliceAccount,
+        bobAccount,
+        charlieAccount,
+        vtpAccount,
     ], signer);
     const legalOfficers = client.legalOfficers;
     const alice = requireDefined(legalOfficers.find(legalOfficer => legalOfficer.address === ALICE.address));
@@ -87,7 +99,13 @@ export async function setupInitialState(): Promise<State> {
         signer,
         alice,
         bob,
-        charlie
+        charlie,
+        requesterAccount,
+        newAccount,
+        aliceAccount,
+        bobAccount,
+        charlieAccount,
+        vtpAccount,
     };
 }
 
@@ -154,8 +172,9 @@ export class LegalOfficerWorker {
 
     async buildLegalOfficerAxios() {
         const { client, signer } = this.state;
-        const authenticatedClient = await client.authenticate([ this.legalOfficer.address ], signer);
-        const token = authenticatedClient.tokens.get(this.legalOfficer.address)!;
+        const legalOfficerAccount = validPolkadotAccountId(client.nodeApi, this.legalOfficer.address);
+        const authenticatedClient = await client.authenticate([ legalOfficerAccount ], signer);
+        const token = authenticatedClient.tokens.get(legalOfficerAccount)!;
         const axiosFactory = new AxiosFactory();
         return axiosFactory.buildAxiosInstance(this.legalOfficer.node, token.value);
     }

--- a/packages/client/integration/Utils.ts
+++ b/packages/client/integration/Utils.ts
@@ -1,4 +1,4 @@
-import { buildApi, UUID } from "@logion/node-api";
+import { buildApi, UUID, Currency, Numbers } from "@logion/node-api";
 import { Keyring } from "@polkadot/api";
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import FormData from "form-data";
@@ -92,10 +92,10 @@ export async function setupInitialState(): Promise<State> {
 }
 
 export async function initRequesterBalance(config: LogionClientConfig, signer: Signer, requester: string): Promise<void> {
-    await transferTokens(config, signer, ALICE.address, requester, 1000000000);
+    await transferTokens(config, signer, ALICE.address, requester, Currency.toCanonicalAmount(new Numbers.PrefixedNumber("10", Numbers.NONE)));
 }
 
-async function transferTokens(config: LogionClientConfig, signer: Signer, source: string, destination: string, amount: number) {
+async function transferTokens(config: LogionClientConfig, signer: Signer, source: string, destination: string, amount: bigint) {
     const api = await buildApi(config.rpcEndpoints);
     await signer.signAndSend({
         signerId: source,

--- a/packages/client/integration/Vault.ts
+++ b/packages/client/integration/Vault.ts
@@ -5,9 +5,9 @@ import { REQUESTER_ADDRESS, State } from "./Utils.js";
 import { checkCoinBalance } from "./Balance.js";
 
 export async function providesVault(state: State) {
-    const { client, signer, alice } = state;
+    const { client, signer, alice, requesterAccount } = state;
 
-    const userClient = client.withCurrentAddress(REQUESTER_ADDRESS);
+    const userClient = client.withCurrentAddress(requesterAccount);
     let activeProtection = (await userClient.protectionState()) as ActiveProtection;
     activeProtection = await activeProtection.waitForFullyReady();
 
@@ -44,11 +44,11 @@ export async function providesVault(state: State) {
 }
 
 export async function aliceAcceptsTransfer(state: State, request: VaultTransferRequest) {
-    const { client, signer, alice } = state;
+    const { client, signer, aliceAccount } = state;
 
     const api = await buildApi(client.config.rpcEndpoints);
 
-    const signerId = alice.address;
+    const signerId = aliceAccount.address;
     const amount = new PrefixedNumber(request!.amount, LGNT_SMALLEST_UNIT);
     const submittable = await approveVaultTransfer({
         signerId,
@@ -64,7 +64,7 @@ export async function aliceAcceptsTransfer(state: State, request: VaultTransferR
         submittable,
     });
 
-    const authenticated = client.withCurrentAddress(alice.address);
-    const axios = authenticated.getLegalOfficer(alice.address).buildAxiosToNode();
+    const authenticated = client.withCurrentAddress(aliceAccount);
+    const axios = authenticated.getLegalOfficer(aliceAccount.address).buildAxiosToNode();
     await axios.post(`/api/vault-transfer-request/${request.id}/accept`);
 }

--- a/packages/client/integration/Vault.ts
+++ b/packages/client/integration/Vault.ts
@@ -39,7 +39,7 @@ export async function providesVault(state: State) {
     vaultState = await vaultState.refresh();
     balanceState = await balanceState.refresh();
 
-    checkCoinBalance(balanceState.balances[0], "2.99k");
+    checkCoinBalance(balanceState.balances[0], "3.01k");
     checkCoinBalance(vaultState.balances[0], "4.00");
 }
 

--- a/packages/client/integration/VerifiedThirdParty.ts
+++ b/packages/client/integration/VerifiedThirdParty.ts
@@ -2,10 +2,10 @@ import { ClosedLoc, EditableRequest, HashOrContent, LocRequestState } from "../s
 import { LegalOfficerWorker, NEW_ADDRESS, State, VTP_ADDRESS } from "./Utils.js";
 
 export async function verifiedThirdParty(state: State) {
-    const { alice } = state;
+    const { alice, vtpAccount, newAccount } = state;
     const legalOfficer = new LegalOfficerWorker(alice, state);
 
-    const vtpClient = state.client.withCurrentAddress(VTP_ADDRESS);
+    const vtpClient = state.client.withCurrentAddress(vtpAccount);
 
     let vtpLocsState = await vtpClient.locsState();
     const pendingRequest = await vtpLocsState.requestIdentityLoc({
@@ -31,7 +31,7 @@ export async function verifiedThirdParty(state: State) {
 
     await legalOfficer.nominateVerifiedThirdParty(VTP_ADDRESS, closedIdentityLoc.locId);
 
-    const userClient = state.client.withCurrentAddress(NEW_ADDRESS);
+    const userClient = state.client.withCurrentAddress(newAccount);
     let newLoc: LocRequestState = await (await userClient.locsState()).requestTransactionLoc({
         legalOfficer: userClient.getLegalOfficer(alice.address),
         description: "Some LOC with VTP",

--- a/packages/client/src/Balance.ts
+++ b/packages/client/src/Balance.ts
@@ -32,7 +32,7 @@ export async function getBalanceState(sharedState: SharedState & { isRecovery: b
     if(sharedState.isRecovery) {
         targetAddress = sharedState.recoveredAddress || "";
     } else {
-        targetAddress = sharedState.currentAddress || "";
+        targetAddress = sharedState.currentAddress?.address || "";
     }
     const client = newTransactionClient(targetAddress, sharedState);
     const transactions = await client.fetchTransactions();
@@ -98,7 +98,7 @@ export class BalanceState extends State {
         }
 
         await signer.signAndSend({
-            signerId: this.sharedState.currentAddress || "",
+            signerId: this.sharedState.currentAddress?.address || "",
             submittable,
             callback,
         })

--- a/packages/client/src/ComponentFactory.ts
+++ b/packages/client/src/ComponentFactory.ts
@@ -17,7 +17,7 @@ export type UploadableData = File | Blob | Buffer | NodeJS.ReadableStream;
 export interface ComponentFactory {
     buildAxiosFactory: () => AxiosFactory;
     buildDirectoryClient: (directoryEndpoint: string, axiosFactory: AxiosFactory, token?: string) => DirectoryClient;
-    buildAuthenticationClient: (directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => AuthenticationClient;
+    buildAuthenticationClient: (api: LogionNodeApi, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => AuthenticationClient;
     buildNetworkState(nodesUp: LegalOfficerEndpoint[], nodesDown: LegalOfficerEndpoint[]): NetworkState<LegalOfficerEndpoint>;
     buildNodeApi(rpcEndpoints: string[]): Promise<LogionNodeApi>;
     buildFormData: () => FormDataLike;
@@ -26,7 +26,7 @@ export interface ComponentFactory {
 export const DefaultComponentFactory: ComponentFactory = {
     buildAxiosFactory: () => new AxiosFactory(),
     buildDirectoryClient: (directoryEndpoint: string, axiosFactory: AxiosFactory, token?: string) => new DirectoryClient(directoryEndpoint, axiosFactory, token),
-    buildAuthenticationClient: (directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => new AuthenticationClient(directoryEndpoint, legalOfficers, axiosFactory),
+    buildAuthenticationClient: (api: LogionNodeApi, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => new AuthenticationClient(api, directoryEndpoint, legalOfficers, axiosFactory),
     buildNetworkState: (nodesUp: LegalOfficerEndpoint[], nodesDown: LegalOfficerEndpoint[]) => new NetworkState(nodesUp, nodesDown),
     buildNodeApi: (rpcEndpoints: string[]) => buildApi(rpcEndpoints),
     buildFormData: () => new FormData(),

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -243,7 +243,7 @@ export class LocsState extends State {
         const client = LocMultiClient.newLocMultiClient(this.sharedState).newLocClient(legalOfficer);
         const request = await client.createLocRequest({
             ownerAddress: legalOfficer.address,
-            requesterAddress: this.sharedState.currentAddress || "",
+            requesterAddress: this.sharedState.currentAddress?.address || "",
             description,
             locType,
             userIdentity,
@@ -381,7 +381,9 @@ export class LocsState extends State {
     private _isVerifiedThirdParty: boolean | undefined;
 
     private computeIsVerifiedThirdParty(): boolean {
-        return this.closedLocs["Identity"].find(loc => loc.data().verifiedThirdParty && loc.data().requesterAddress?.address === this.sharedState.currentAddress) !== undefined;
+        return this.closedLocs["Identity"].find(loc => loc.data().verifiedThirdParty
+            && loc.data().requesterAddress?.address === this.sharedState.currentAddress?.address
+            && loc.data().requesterAddress?.type === this.sharedState.currentAddress?.type) !== undefined;
     }
 
     get openVerifiedThirdPartyLocs(): Record<LocType, OpenLoc[]> {

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -1,4 +1,4 @@
-import { UUID, LegalOfficerCase, LocType, VoidInfo, ItemFile, VerifiedIssuer } from "@logion/node-api";
+import { UUID, LegalOfficerCase, LocType, VoidInfo, ItemFile, VerifiedIssuer, ValidAccountId, AnyAccountId, LogionNodeApi } from "@logion/node-api";
 
 import {
     LocRequest,
@@ -36,7 +36,7 @@ import { downloadFile, TypedFile } from "./Http.js";
 export interface LocData extends LocVerifiedIssuers {
     id: UUID
     ownerAddress: string;
-    requesterAddress?: string;
+    requesterAddress?: ValidAccountId;
     requesterLocId?: UUID;
     description: string;
     locType: LocType;
@@ -381,7 +381,7 @@ export class LocsState extends State {
     private _isVerifiedThirdParty: boolean | undefined;
 
     private computeIsVerifiedThirdParty(): boolean {
-        return this.closedLocs["Identity"].find(loc => loc.data().verifiedThirdParty && loc.data().requesterAddress === this.sharedState.currentAddress) !== undefined;
+        return this.closedLocs["Identity"].find(loc => loc.data().verifiedThirdParty && loc.data().requesterAddress?.address === this.sharedState.currentAddress) !== undefined;
     }
 
     get openVerifiedThirdPartyLocs(): Record<LocType, OpenLoc[]> {
@@ -513,14 +513,14 @@ export abstract class LocRequestState extends State {
 
     data(): LocData {
         this.ensureCurrent();
-        return LocRequestState.buildLocData(this.legalOfficerCase, this.request, this.locIssuers);
+        return LocRequestState.buildLocData(this.locSharedState.nodeApi, this.legalOfficerCase, this.request, this.locIssuers);
     }
 
-    static buildLocData(legalOfficerCase: LegalOfficerCase | undefined, request: LocRequest, locIssuers: LocVerifiedIssuers): LocData {
+    static buildLocData(api: LogionNodeApi, legalOfficerCase: LegalOfficerCase | undefined, request: LocRequest, locIssuers: LocVerifiedIssuers): LocData {
         if (legalOfficerCase) {
             return LocRequestState.dataFromRequestAndLoc(request, legalOfficerCase, locIssuers);
         } else {
-            return LocRequestState.dataFromRequest(request, locIssuers);
+            return LocRequestState.dataFromRequest(api, request, locIssuers);
         }
     }
 
@@ -568,11 +568,11 @@ export abstract class LocRequestState extends State {
         return result;
     }
 
-    private static dataFromRequest(request: LocRequest, locIssuers: LocVerifiedIssuers): LocData {
+    private static dataFromRequest(api: LogionNodeApi, request: LocRequest, locIssuers: LocVerifiedIssuers): LocData {
         return {
             ...request,
             ...locIssuers,
-            requesterAddress: request.requesterAddress || undefined,
+            requesterAddress: request.requesterAddress ? new AnyAccountId(api, request.requesterAddress, "Polkadot").toValidAccountId() : undefined,
             requesterLocId: request.requesterIdentityLoc ? new UUID(request.requesterIdentityLoc) : undefined,
             id: new UUID(request.id),
             closed: false,
@@ -590,7 +590,6 @@ export abstract class LocRequestState extends State {
         const data: LocData = {
             ...loc,
             ...locIssuers,
-            requesterAddress: loc.requesterAddress?.address,
             id: new UUID(request.id),
             ownerAddress: loc.owner,
             closedOn: request.closedOn,

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -311,7 +311,7 @@ export class LocMultiClient {
         const { currentAddress, token } = authenticatedCurrentAddress(sharedState);
         return new LocMultiClient({
             axiosFactory: sharedState.axiosFactory,
-            currentAddress,
+            currentAddress: currentAddress.address,
             networkState: sharedState.networkState,
             token: token.value,
             nodeApi: sharedState.nodeApi,

--- a/packages/client/src/Public.ts
+++ b/packages/client/src/Public.ts
@@ -35,7 +35,7 @@ export class PublicApi {
         const { loc, client } = locAndClient;
 
         const locRequest = await client.getLocRequest(params);
-        const data = LocRequestState.buildLocData(loc, locRequest, EMPTY_LOC_ISSUERS);
+        const data = LocRequestState.buildLocData(this.sharedState.nodeApi, loc, locRequest, EMPTY_LOC_ISSUERS);
         return new PublicLoc({
             data,
             client,

--- a/packages/client/src/Recovery.ts
+++ b/packages/client/src/Recovery.ts
@@ -518,7 +518,7 @@ export class RejectedRecovery extends State implements WithProtectionParameters 
     private async _cancel(): Promise<NoProtection> {
         return Promise.all(this.sharedState.allRequests.map(request => {
             if (request instanceof CancellableRequest) {
-                request.cancel()
+                return request.cancel();
             } else {
                 return Promise.reject("Request cannot be cancelled.")
             }

--- a/packages/client/src/Recovery.ts
+++ b/packages/client/src/Recovery.ts
@@ -211,7 +211,7 @@ export class NoProtection extends State {
     }): Promise<PendingProtection> {
         const loRecoveryClient1 = newLoRecoveryClient(this.sharedState, params.legalOfficer1);
         const protection1 = await loRecoveryClient1.createProtectionRequest({
-            requesterAddress: getDefinedCurrentAddress(this.sharedState),
+            requesterAddress: getDefinedCurrentAddress(this.sharedState).address,
             legalOfficerAddress: params.legalOfficer1.address,
             otherLegalOfficerAddress: params.legalOfficer2.address,
             userIdentity: params.userIdentity,
@@ -221,7 +221,7 @@ export class NoProtection extends State {
         });
         const loRecoveryClient2 = newLoRecoveryClient(this.sharedState, params.legalOfficer2);
         const protection2 = await loRecoveryClient2.createProtectionRequest({
-            requesterAddress: getDefinedCurrentAddress(this.sharedState),
+            requesterAddress: getDefinedCurrentAddress(this.sharedState).address,
             legalOfficerAddress: params.legalOfficer2.address,
             otherLegalOfficerAddress: params.legalOfficer1.address,
             userIdentity: params.userIdentity,
@@ -260,7 +260,7 @@ export class NoProtection extends State {
         const activeRecovery = await getActiveRecovery({
             api: this.sharedState.nodeApi,
             sourceAccount: params.recoveredAddress,
-            destinationAccount: currentAddress,
+            destinationAccount: currentAddress.address,
         });
         if (activeRecovery === undefined) {
             const recoveryConfig = await getRecoveryConfig({
@@ -272,7 +272,7 @@ export class NoProtection extends State {
                 recoveryConfig.legalOfficers.includes(params.legalOfficer2.address)
             ) {
                 await params.signer.signAndSend({
-                    signerId: currentAddress,
+                    signerId: currentAddress.address,
                     submittable: initiateRecovery({
                         api: this.sharedState.nodeApi,
                         addressToRecover: params.recoveredAddress,
@@ -295,7 +295,7 @@ function newRecoveryClient(sharedState: SharedState): RecoveryClient {
     const { currentAddress, token } = authenticatedCurrentAddress(sharedState);
     return new RecoveryClient({
         axiosFactory: sharedState.axiosFactory,
-        currentAddress,
+        currentAddress: currentAddress.address,
         networkState: sharedState.networkState,
         token: token.value,
         nodeApi: sharedState.nodeApi,
@@ -579,7 +579,7 @@ export class RejectedProtection extends RejectedRecovery {
     private createNewRequest(requestToCancel: ProtectionRequest, otherRequest: ProtectionRequest, newLegalOfficer: LegalOfficer): Promise<ProtectionRequest> {
         const loRecoveryClient = newLoRecoveryClient(this.sharedState, newLegalOfficer);
         return loRecoveryClient.createProtectionRequest({
-            requesterAddress: getDefinedCurrentAddress(this.sharedState),
+            requesterAddress: getDefinedCurrentAddress(this.sharedState).address,
             legalOfficerAddress: newLegalOfficer.address,
             otherLegalOfficerAddress: otherRequest.legalOfficerAddress,
             userIdentity: requestToCancel.userIdentity,
@@ -611,7 +611,7 @@ export class AcceptedProtection extends State implements WithProtectionParameter
         callback?: SignCallback,
     ): Promise<ActiveProtection | PendingRecovery> {
         await signer.signAndSend({
-            signerId: getDefinedCurrentAddress(this.sharedState),
+            signerId: getDefinedCurrentAddress(this.sharedState).address,
             submittable: createRecovery({
                 api: this.sharedState.nodeApi,
                 legalOfficers: this.sharedState.selectedLegalOfficers.map(legalOfficer => legalOfficer.address),
@@ -746,7 +746,7 @@ export class PendingRecovery extends State implements WithProtectionParameters, 
     ): Promise<ClaimedRecovery> {
         const addressToRecover = this.protectionParameters.recoveredAddress || "";
         await signer.signAndSend({
-            signerId: getDefinedCurrentAddress(this.sharedState),
+            signerId: getDefinedCurrentAddress(this.sharedState).address,
             submittable: claimRecovery({
                 api: this.sharedState.nodeApi,
                 addressToRecover,

--- a/packages/client/src/SharedClient.ts
+++ b/packages/client/src/SharedClient.ts
@@ -1,4 +1,4 @@
-import { LogionNodeApi } from "@logion/node-api";
+import { LogionNodeApi, ValidAccountId } from "@logion/node-api";
 
 import { AccountTokens } from "./AuthenticationClient.js";
 import { AxiosFactory } from "./AxiosFactory.js";
@@ -29,14 +29,14 @@ export interface SharedState {
     legalOfficers: LegalOfficerClass[];
     allLegalOfficers: LegalOfficerClass[];
     tokens: AccountTokens;
-    currentAddress?: string;
+    currentAddress?: ValidAccountId;
 }
 
 export function getLegalOfficer(sharedState: SharedState, address: string): LegalOfficerClass {
     return findOrThrow(sharedState.legalOfficers, lo => lo.address === address, `No legal officer with address ${address}`);
 }
 
-export function authenticatedCurrentAddress(sharedState: SharedState): { currentAddress: string, token: Token } {
+export function authenticatedCurrentAddress(sharedState: SharedState): { currentAddress: ValidAccountId, token: Token } {
     const currentAddress = getDefinedCurrentAddress(sharedState);
     const token = sharedState.tokens.get(currentAddress);
     if(!token) {
@@ -48,7 +48,7 @@ export function authenticatedCurrentAddress(sharedState: SharedState): { current
     };
 }
 
-export function getDefinedCurrentAddress(sharedState: SharedState): string {
+export function getDefinedCurrentAddress(sharedState: SharedState): ValidAccountId {
     const { currentAddress } = sharedState;
     if(!currentAddress) {
         throw new Error("No current address");

--- a/packages/client/src/Signer.ts
+++ b/packages/client/src/Signer.ts
@@ -175,10 +175,6 @@ export class KeyringSigner extends BaseSigner {
     private keyring: Keyring;
 
     async signToHex(signerId: ValidAccountId, message: string): Promise<TypedSignature> {
-        if(signerId.type !== "Polkadot") {
-            throw new Error(`Unsupported account type ${signerId.type}`);
-        }
-
         const keypair = this.keyring.getPair(signerId.address);
         const bytes = keypair.sign(message);
         const signature = '0x' + Buffer.from(bytes).toString('hex');

--- a/packages/client/src/Signer.ts
+++ b/packages/client/src/Signer.ts
@@ -4,14 +4,14 @@ import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { ISubmittableResult } from '@polkadot/types/types';
 import { base64Encode } from '@polkadot/util-crypto';
 import { Registry } from '@polkadot/types-codec/types';
-import { toHex, getErrorMessage, Event, getExtrinsicEvents } from '@logion/node-api';
+import { toHex, getErrorMessage, Event, getExtrinsicEvents, ValidAccountId } from '@logion/node-api';
 import { Hash } from 'fast-sha256';
 
 import { toIsoString } from "./DateTimeUtil.js";
 import { requireDefined } from "./assertions.js";
 
 export interface SignRawParameters {
-    signerId: string;
+    signerId: ValidAccountId;
     resource: string;
     operation: string;
     signedOn: DateTime;
@@ -86,7 +86,7 @@ export abstract class BaseSigner implements FullSigner {
         return await this.signToHex(parameters.signerId, message);
     }
 
-    abstract signToHex(signerId: string, message: string): Promise<TypedSignature>;
+    abstract signToHex(signerId: ValidAccountId, message: string): Promise<TypedSignature>;
 
     buildMessage(parameters: SignRawParameters): string {
         return toHex(hashAttributes(this.buildAttributes(parameters)));
@@ -174,8 +174,12 @@ export class KeyringSigner extends BaseSigner {
 
     private keyring: Keyring;
 
-    async signToHex(signerId: string, message: string): Promise<TypedSignature> {
-        const keypair = this.keyring.getPair(signerId);
+    async signToHex(signerId: ValidAccountId, message: string): Promise<TypedSignature> {
+        if(signerId.type !== "Polkadot") {
+            throw new Error(`Unsupported account type ${signerId.type}`);
+        }
+
+        const keypair = this.keyring.getPair(signerId.address);
         const bytes = keypair.sign(message);
         const signature = '0x' + Buffer.from(bytes).toString('hex');
         const type: SignatureType = keypair.type === "ethereum" ? "ETHEREUM" : "POLKADOT";

--- a/packages/client/src/Vault.ts
+++ b/packages/client/src/Vault.ts
@@ -45,9 +45,9 @@ export class VaultState extends State {
         const client = new VaultClient({
             axiosFactory: sharedState.axiosFactory,
             networkState: sharedState.networkState,
-            currentAddress,
+            currentAddress: currentAddress.address,
             token: token.value,
-            isLegalOfficer: sharedState.legalOfficers.find(legalOfficer => legalOfficer.address === currentAddress) !== undefined,
+            isLegalOfficer: sharedState.legalOfficers.find(legalOfficer => legalOfficer.address === currentAddress.address) !== undefined,
             isRecovery: sharedState.isRecovery,
         });
         const result = await client.fetchAll(sharedState.selectedLegalOfficers);
@@ -85,7 +85,7 @@ export class VaultState extends State {
             );
         } else {
             const { currentAddress } = authenticatedCurrentAddress(sharedState);
-            return getVaultAddress(currentAddress, sharedState.selectedLegalOfficers.map(legalOfficer => legalOfficer.address));
+            return getVaultAddress(currentAddress.address, sharedState.selectedLegalOfficers.map(legalOfficer => legalOfficer.address));
         }
     }
 
@@ -150,7 +150,7 @@ export class VaultState extends State {
         const { amount, destination, signer, callback, legalOfficer } = params;
 
         const currentAddress = getDefinedCurrentAddress(this.sharedState);
-        const signerId = currentAddress;
+        const signerId = currentAddress.address;
 
         let submittable: SubmittableExtrinsic;
         if(this.sharedState.isRecovery) {
@@ -214,7 +214,7 @@ export class VaultState extends State {
     }): Promise<SubmittableExtrinsic> {
         const { destination, amount } = params;
         return requestVaultTransfer({
-            signerId: getDefinedCurrentAddress(this.sharedState),
+            signerId: getDefinedCurrentAddress(this.sharedState).address,
             api: this.sharedState.nodeApi,
             amount,
             destination,
@@ -237,7 +237,7 @@ export class VaultState extends State {
         signer: Signer,
         callback?: SignCallback,
     ): Promise<VaultState> {
-        const signerId = getDefinedCurrentAddress(this.sharedState);
+        const signerId = getDefinedCurrentAddress(this.sharedState).address;
         const amount = new PrefixedNumber(request.amount, LGNT_SMALLEST_UNIT);
 
         let submittable: SubmittableExtrinsic;

--- a/packages/client/src/Voter.ts
+++ b/packages/client/src/Voter.ts
@@ -58,7 +58,7 @@ export class VoterApi {
             ...this.sharedState,
             axiosFactory: this.sharedState.axiosFactory,
             nodeApi: this.sharedState.nodeApi,
-            currentAddress: this.sharedState.currentAddress,
+            currentAddress: this.sharedState.currentAddress.address,
             legalOfficer,
         });
         const locRequest = await client.getLocRequest({ locId });

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -834,7 +834,8 @@ async function getVoidedCollectionLoc() {
 function expectDataToMatch(data: LocData, request: LocRequest) {
     expect(data.id.toString()).toBe(request.id.toString());
     expect(data.ownerAddress).toBe(request.ownerAddress);
-    expect(data.requesterAddress).toBe(request.requesterAddress ? request.requesterAddress : undefined);
+    expect(data.requesterAddress?.address).toBe(request.requesterAddress ? request.requesterAddress : undefined);
+    expect(data.requesterAddress?.type).toBe(request.requesterAddress ? "Polkadot" : undefined);
     expect(data.requesterLocId?.toString()).toBe(request.requesterIdentityLoc ? request.requesterIdentityLoc : undefined);
     expect(data.description).toBe(request.description);
     expect(data.locType).toBe(request.locType);

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -47,7 +47,8 @@ import {
     mockEmptyOption,
     mockOption,
     REQUESTER,
-    SUCCESSFUL_SUBMISSION
+    SUCCESSFUL_SUBMISSION,
+    buildSimpleNodeApi
 } from "./Utils.js";
 import { TestConfigFactory } from "./TestConfigFactory.js";
 import {
@@ -244,7 +245,7 @@ describe("ClosedCollectionLoc", () => {
         const closedLoc = await getClosedCollectionLoc();
 
         const signer = new Mock<Signer>();
-        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER))).returnsAsync(SUCCESSFUL_SUBMISSION);
+        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER.address))).returnsAsync(SUCCESSFUL_SUBMISSION);
         await closedLoc.addCollectionItem({
             itemId: ITEM_ID,
             itemDescription: ITEM_DESCRIPTION,
@@ -258,7 +259,7 @@ describe("ClosedCollectionLoc", () => {
         const closedLoc = await getClosedCollectionLoc();
 
         const signer = new Mock<Signer>();
-        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER))).returnsAsync(SUCCESSFUL_SUBMISSION);
+        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER.address))).returnsAsync(SUCCESSFUL_SUBMISSION);
         await closedLoc.addCollectionItem({
             itemId: ITEM_ID,
             itemDescription: ITEM_DESCRIPTION,
@@ -274,7 +275,7 @@ describe("ClosedCollectionLoc", () => {
         const closedLoc = await getClosedCollectionLoc();
 
         const signer = new Mock<Signer>();
-        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER))).returnsAsync(SUCCESSFUL_SUBMISSION);
+        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER.address))).returnsAsync(SUCCESSFUL_SUBMISSION);
         await closedLoc.addCollectionItem({
             itemId: ITEM_ID,
             itemDescription: ITEM_DESCRIPTION,
@@ -290,7 +291,7 @@ describe("ClosedCollectionLoc", () => {
         const closedLoc = await getClosedCollectionLoc();
 
         const signer = new Mock<Signer>();
-        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER))).returnsAsync(SUCCESSFUL_SUBMISSION);
+        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER.address))).returnsAsync(SUCCESSFUL_SUBMISSION);
         // expectAsync(closedCollectionLoc).toBeRejected("Logion Classification and Creative Commons are mutually exclusive.");
         await expectAsync(closedLoc.addCollectionItem({
                 itemId: ITEM_ID,
@@ -359,7 +360,7 @@ describe("ClosedCollectionLoc", () => {
     it("adds tokens record", async () => {
         const closedLoc = await getClosedCollectionLoc();
         const signer = new Mock<Signer>();
-        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER))).returnsAsync(SUCCESSFUL_SUBMISSION);
+        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER.address))).returnsAsync(SUCCESSFUL_SUBMISSION);
 
         await closedLoc.addTokensRecord({
             recordId: RECORD_ID,
@@ -514,12 +515,15 @@ let nodeApiMock: Mock<LogionNodeApi>;
 async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<SharedState> {
     const currentAddress = isVerifiedThirdParty ? ISSUER : REQUESTER;
     const token = "some-token";
-    const tokens = new AccountTokens({
-        [currentAddress]: {
-            value: token,
-            expirationDateTime: DateTime.now().plus({ hours: 1 })
+    const tokens = new AccountTokens(
+        buildSimpleNodeApi(),
+        {
+            [currentAddress.toKey()]: {
+                value: token,
+                expirationDateTime: DateTime.now().plus({ hours: 1 })
+            }
         }
-    });
+    );
     return await buildTestAuthenticatedSharedSate(
         (factory: TestConfigFactory) => {
             factory.setupDefaultNetworkState();
@@ -536,7 +540,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                 ALICE_CLOSED_COLLECTION_LOC.request,
                 ALICE_REJECTED_TRANSACTION_LOC_REQUEST,
             ];
-            aliceAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === REQUESTER)))
+            aliceAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === REQUESTER.address)))
                 .returnsAsync({
                     data: {
                         requests: aliceRequests
@@ -544,7 +548,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                 } as AxiosResponse);
 
             if(isVerifiedThirdParty) {
-                aliceAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === ISSUER)))
+                aliceAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === ISSUER.address)))
                     .returnsAsync({
                         data: {
                             requests: [ALICE_CLOSED_IDENTITY_LOC_WITH_VTP.request]
@@ -602,7 +606,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                 BOB_VOID_COLLECTION_LOC.request,
                 BOB_CLOSED_IDENTITY_LOC.request,
             ];
-            bobAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === REQUESTER)))
+            bobAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === REQUESTER.address)))
                 .returnsAsync({
                     data: {
                         requests: bobRequests
@@ -624,7 +628,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
             const charlieRequests: LocRequest[] = [
                 CHARLIE_VOID_IDENTITY_LOC.request,
             ];
-            charlieAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === REQUESTER)))
+            charlieAxiosMock.setup(instance => instance.put("/api/loc-request", It.Is<FetchLocRequestSpecification>(params => params.requesterAddress === REQUESTER.address)))
                 .returnsAsync({
                     data: {
                         requests: charlieRequests
@@ -694,7 +698,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                 if(!isVerifiedThirdParty) {
                     return Promise.resolve(mockEmptyOption<PalletLogionLocVerifiedIssuer>());
                 } else {
-                    if(legalOfficer === ALICE.address && issuer === ISSUER) {
+                    if(legalOfficer === ALICE.address && issuer === ISSUER.address) {
                         return Promise.resolve(mockEmptyOption<PalletLogionLocVerifiedIssuer>());
                     } else {
                         const verifiedIssuer: PalletLogionLocVerifiedIssuer = mockCodecWithToString(new UUID(ALICE_CLOSED_IDENTITY_LOC_WITH_VTP.request.id).toDecimalString());
@@ -714,7 +718,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                             {
                                 args: [
                                     mockCodecWithToString(ALICE.address),
-                                    mockCodecWithToString(ISSUER),
+                                    mockCodecWithToString(ISSUER.address),
                                 ],
                             } as any,
                             mockOption(verifiedIssuer as PalletLogionLocVerifiedIssuer),
@@ -729,11 +733,11 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
             nodeApiMock.setup(instance => instance.query.logionLoc.verifiedIssuersByLocMap.multi).returns(verifiedIssuersByLocMapMultiImpl);
 
             if(isVerifiedThirdParty) {
-                nodeApiMock.setup(instance => instance.query.logionLoc.locsByVerifiedIssuerMap.entries(ISSUER)).returns(Promise.resolve([
+                nodeApiMock.setup(instance => instance.query.logionLoc.locsByVerifiedIssuerMap.entries(ISSUER.address)).returns(Promise.resolve([
                     [
                         {
                             args: [
-                                mockCodecWithToString(ISSUER),
+                                mockCodecWithToString(ISSUER.address),
                                 mockCodecWithToString(ALICE.address),
                                 mockCodecWithToString(new UUID(ALICE_OPEN_TRANSACTION_LOC_WITH_SELECTED_VTP.request.id).toDecimalString()),
                             ],
@@ -743,7 +747,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                     [
                         {
                             args: [
-                                mockCodecWithToString(ISSUER),
+                                mockCodecWithToString(ISSUER.address),
                                 mockCodecWithToString(ALICE.address),
                                 mockCodecWithToString(new UUID(ALICE_CLOSED_TRANSACTION_LOC_WITH_SELECTED_VTP.request.id).toDecimalString()),
                             ],
@@ -751,7 +755,7 @@ async function buildSharedState(isVerifiedThirdParty: boolean = false): Promise<
                         mockCodecWithToString(""),
                     ]
                 ]));
-                nodeApiMock.setup(instance => instance.query.logionLoc.locsByVerifiedIssuerMap.entries(REQUESTER)).returns(Promise.resolve([]));
+                nodeApiMock.setup(instance => instance.query.logionLoc.locsByVerifiedIssuerMap.entries(REQUESTER.address)).returns(Promise.resolve([]));
             } else {
                 nodeApiMock.setup(instance => instance.query.logionLoc.locsByVerifiedIssuerMap.entries(It.IsAny())).returns(Promise.resolve([]));
             }

--- a/packages/client/test/LogionClient.spec.ts
+++ b/packages/client/test/LogionClient.spec.ts
@@ -19,8 +19,11 @@ import {
     buildAuthenticatedSharedStateUsingTestConfig,
     buildTestAuthenticatedSharedSate,
     buildTestConfig,
-    LOGION_CLIENT_CONFIG
+    LOGION_CLIENT_CONFIG,
+    buildValidPolkadotAccountId,
+    buildSimpleNodeApi
 } from './Utils.js';
+import { LogionNodeApi } from '@logion/node-api';
 
 describe("LogionClient", () => {
 
@@ -46,10 +49,11 @@ describe("LogionClient", () => {
     it("uses tokens", async () => {
         const clientLegalOfficers: LegalOfficer[] = [ ALICE ];
         const token = 'token';
+        let api: Mock<LogionNodeApi>;
         const config = buildTestConfig(testConfigFactory => {
             testConfigFactory.setupDefaultAxiosInstanceFactory();
             testConfigFactory.setupDefaultNetworkState();
-            testConfigFactory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
+            api = testConfigFactory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
             const directoryClient = testConfigFactory.setupDirectoryClientMock(LOGION_CLIENT_CONFIG);
             directoryClient.setup(instance => instance.getLegalOfficers())
                 .returns(Promise.resolve(testConfigFactory.buildLegalOfficerClasses(clientLegalOfficers)));
@@ -57,7 +61,7 @@ describe("LogionClient", () => {
         });
         const client = await LogionClient.create(config);
 
-        const tokens = buildAliceTokens(DateTime.now().plus({hours: 1}));
+        const tokens = buildAliceTokens(api!.object(), DateTime.now().plus({hours: 1}));
 
         const authenticatedClient = client.useTokens(tokens);
 
@@ -67,9 +71,9 @@ describe("LogionClient", () => {
     it("authenticates", async () => {
         const clientLegalOfficers: LegalOfficer[] = [ ALICE ];
         const token = 'token';
-        const addresses = [ ALICE.address ];
+        const addresses = [ buildValidPolkadotAccountId(ALICE.address)! ];
         const signer = new Mock<RawSigner>();
-        const tokens = buildAliceTokens(DateTime.now().plus({hours: 1}));
+        const tokens = buildAliceTokens(buildSimpleNodeApi(), DateTime.now().plus({hours: 1}));
         const config = buildTestConfig(testConfigFactory => {
             testConfigFactory.setupDefaultAxiosInstanceFactory();
             testConfigFactory.setupDefaultNetworkState();
@@ -84,7 +88,7 @@ describe("LogionClient", () => {
             authenticationClient.setup(instance => instance.authenticate(addresses, signer.object()))
                 .returns(Promise.resolve(tokens));
 
-                testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
+            testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
         });
         const client = await LogionClient.create(config);
 
@@ -97,16 +101,17 @@ describe("LogionClient", () => {
 
     it("refreshes tokens", async () => {
         const legalOfficers: LegalOfficer[] = [ ALICE ];
-        const tokens = buildAliceTokens(DateTime.now().plus({minutes: 10}));
         let authenticationClient: Mock<AuthenticationClient>;
+        const alice = buildValidPolkadotAccountId(ALICE.address);
+        const tokens = buildAliceTokens(buildSimpleNodeApi(), DateTime.now().plus({minutes: 10}));
         const sharedState = await buildTestAuthenticatedSharedSate(testConfigFactory => {
             testConfigFactory.setupDefaultAxiosInstanceFactory();
             testConfigFactory.setupDefaultNetworkState();
             testConfigFactory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-            testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(ALICE.address)!.value);
+            testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(alice)!.value);
             authenticationClient = testConfigFactory.setupAuthenticationClientMock(LOGION_CLIENT_CONFIG, legalOfficers);
             authenticationClient.setup(instance => instance.refresh(tokens)).returns(Promise.resolve(tokens));
-        }, ALICE.address, legalOfficers, tokens);
+        }, alice, legalOfficers, tokens);
         const client = new LogionClient({ ...sharedState });
 
         await client.refreshTokens(DateTime.now(), {minutes: 15});
@@ -116,16 +121,17 @@ describe("LogionClient", () => {
 
     it("skips token refresh if earliest above threshold", async () => {
         const legalOfficers: LegalOfficer[] = [ ALICE ];
-        const tokens = buildAliceTokens(DateTime.now().plus({hours: 1}));
+        const alice = buildValidPolkadotAccountId(ALICE.address);
+        const tokens = buildAliceTokens(buildSimpleNodeApi(), DateTime.now().plus({hours: 1}));
         let authenticationClient: Mock<AuthenticationClient>;
         const sharedState = await buildTestAuthenticatedSharedSate(testConfigFactory => {
             testConfigFactory.setupDefaultAxiosInstanceFactory();
             testConfigFactory.setupDefaultNetworkState();
             testConfigFactory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-            testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(ALICE.address)!.value);
+            testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(alice)!.value);
             authenticationClient = testConfigFactory.setupAuthenticationClientMock(LOGION_CLIENT_CONFIG, legalOfficers);
             authenticationClient.setup(instance => instance.refresh(tokens)).returns(Promise.resolve(tokens));
-        }, ALICE.address, legalOfficers, tokens);
+        }, alice, legalOfficers, tokens);
         const client = new LogionClient({ ...sharedState });
 
         await client.refreshTokens(DateTime.now(), {minutes: 30});
@@ -135,37 +141,40 @@ describe("LogionClient", () => {
 
     it("changes current address", async () => {
         const legalOfficers: LegalOfficer[] = [ ALICE ];
-        const tokens = buildAliceAndBobTokens(DateTime.now().plus({hours: 1}));
+        const tokens = buildAliceAndBobTokens(buildSimpleNodeApi(), DateTime.now().plus({hours: 1}));
         const testConfigFactory = new TestConfigFactory();
 
         testConfigFactory.setupDefaultAxiosInstanceFactory();
         testConfigFactory.setupDefaultNetworkState();
         testConfigFactory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-        testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(ALICE.address)!.value);
-        testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(BOB.address)!.value);
+        const alice = buildValidPolkadotAccountId(ALICE.address);
+        testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(alice)!.value);
+        const bob = buildValidPolkadotAccountId(BOB.address);
+        testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(bob)!.value);
         testConfigFactory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
 
         const config = testConfigFactory.buildTestConfig(LOGION_CLIENT_CONFIG);
-        const sharedState = await buildAuthenticatedSharedStateUsingTestConfig(config, ALICE.address, legalOfficers, tokens);
+        const sharedState = await buildAuthenticatedSharedStateUsingTestConfig(config, alice, legalOfficers, tokens);
         const aliceClient = new LogionClient({ ...sharedState });
 
-        const bobClient = aliceClient.withCurrentAddress(BOB.address);
+        const bobClient = aliceClient.withCurrentAddress(bob);
 
-        expect(bobClient.currentAddress).toBe(BOB.address);
-        testConfigFactory.verifyComponentFactory(instance => instance.buildDirectoryClient(DIRECTORY_ENDPOINT, It.IsAny(), tokens.get(BOB.address)!.value));
+        expect(bobClient.currentAddress).toBe(bob);
+        testConfigFactory.verifyComponentFactory(instance => instance.buildDirectoryClient(DIRECTORY_ENDPOINT, It.IsAny(), tokens.get(bob)!.value));
     });
 
     it("logs out", async () => {
         const legalOfficers: LegalOfficer[] = [ ALICE ];
-        const tokens = buildAliceTokens(DateTime.now().plus({hours: 1}));
+        const tokens = buildAliceTokens(buildSimpleNodeApi(), DateTime.now().plus({hours: 1}));
 
+        const alice = buildValidPolkadotAccountId(ALICE.address);
         const sharedState = await buildTestAuthenticatedSharedSate(testConfigFactory => {
             testConfigFactory.setupDefaultAxiosInstanceFactory();
             testConfigFactory.setupDefaultNetworkState();
             testConfigFactory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-            testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(ALICE.address)!.value);
+            testConfigFactory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, tokens.get(alice)!.value);
             testConfigFactory.setupAuthenticationClientMock(LOGION_CLIENT_CONFIG, legalOfficers);
-        }, ALICE.address, legalOfficers, tokens);
+        }, alice, legalOfficers, tokens);
         const authenticatedClient = new LogionClient({ ...sharedState });
 
         const client = authenticatedClient.logout();

--- a/packages/client/test/Public.spec.ts
+++ b/packages/client/test/Public.spec.ts
@@ -14,6 +14,7 @@ import {
 } from "../src/index.js";
 import {
     ALICE,
+    buildSimpleNodeApi,
     buildTestAuthenticatedSharedSate,
     LEGAL_OFFICERS,
     LOGION_CLIENT_CONFIG,
@@ -190,6 +191,6 @@ async function buildSharedState(): Promise<SharedState> {
         },
         undefined,
         LEGAL_OFFICERS,
-        new AccountTokens({}),
+        new AccountTokens(buildSimpleNodeApi(), {}),
     );
 }

--- a/packages/client/test/TestConfigFactory.ts
+++ b/packages/client/test/TestConfigFactory.ts
@@ -12,6 +12,7 @@ import {
     LegalOfficer,
     LegalOfficerClass
 } from "../src/index.js";
+import { buildSimpleNodeApi } from "./Utils.js";
 
 export class TestConfigFactory {
 
@@ -57,9 +58,11 @@ export class TestConfigFactory {
 
     setupAuthenticationClientMock(config: LogionClientConfig, legalOfficers: LegalOfficer[]): Mock<AuthenticationClient> {
         const authenticationClient = new Mock<AuthenticationClient>();
-        this._componentFactory.setup(instance => instance.buildAuthenticationClient(config.directoryEndpoint,
-                It.Is<LegalOfficerClass[]>(value => legalOfficers.map(lo => lo.address).every(item => value.map(lo => lo.address).includes(item))), It.IsAny()))
-            .returns(authenticationClient.object());
+        this._componentFactory.setup(instance => instance.buildAuthenticationClient(
+            It.IsAny(),
+            config.directoryEndpoint,
+            It.Is<LegalOfficerClass[]>(value => legalOfficers.map(lo => lo.address).every(item => value.map(lo => lo.address).includes(item))), It.IsAny()
+        )).returns(authenticationClient.object());
         return authenticationClient;
     }
 

--- a/packages/client/test/Voter.spec.ts
+++ b/packages/client/test/Voter.spec.ts
@@ -11,7 +11,9 @@ import {
 } from "../src/index.js";
 import {
     ALICE,
+    buildSimpleNodeApi,
     buildTestAuthenticatedSharedSate,
+    buildValidPolkadotAccountId,
     LEGAL_OFFICERS,
     LOGION_CLIENT_CONFIG,
 } from "./Utils.js";
@@ -25,7 +27,8 @@ describe("VoterApi", () => {
 
     it("finds LOC", async () => {
         const sharedState = await buildSharedState();
-        const logionClient = new LogionClient(sharedState).useTokens(tokens).withCurrentAddress(ALICE.address);
+        const alice = buildValidPolkadotAccountId(ALICE.address);
+        const logionClient = new LogionClient(sharedState).useTokens(tokens).withCurrentAddress(alice);
         const voterApi = new VoterApi({ sharedState, logionClient });
 
         const readOnlyState = await voterApi.findLocById(new UUID(LOC_REQUEST.id));
@@ -41,14 +44,17 @@ const LOC = buildLoc(ALICE.address, "CLOSED", "Identity");
 let aliceAxiosMock: Mock<AxiosInstance>;
 let nodeApiMock: Mock<LogionNodeApi>;
 
-const currentAddress = ALICE.address;
+const currentAddress = buildValidPolkadotAccountId(ALICE.address);
 const token = "some-token";
-const tokens = new AccountTokens({
-    [ALICE.address]: {
-        value: token,
-        expirationDateTime: DateTime.now().plus({ hours: 1 })
+const tokens = new AccountTokens(
+    buildSimpleNodeApi(),
+    {
+        [`${currentAddress?.toKey()}`]: {
+            value: token,
+            expirationDateTime: DateTime.now().plus({ hours: 1 })
+        }
     }
-});
+);
 
 async function buildSharedState(): Promise<SharedState> {
     return await buildTestAuthenticatedSharedSate(

--- a/packages/crossmint/src/CrossmintSigner.ts
+++ b/packages/crossmint/src/CrossmintSigner.ts
@@ -1,5 +1,6 @@
 import { CrossmintEVMWalletAdapter } from "@crossmint/connect";
 import { BaseSigner, SignAndSendFunction, TypedSignature } from "@logion/client";
+import { ValidAccountId } from "@logion/node-api";
 
 export class CrossmintSigner extends BaseSigner {
 
@@ -13,7 +14,7 @@ export class CrossmintSigner extends BaseSigner {
 
     private crossmint: CrossmintEVMWalletAdapter;
 
-    async signToHex(_signerId: string, message: string): Promise<TypedSignature> {
+    async signToHex(_signerId: ValidAccountId, message: string): Promise<TypedSignature> {
         const signature = await this.crossmint.signMessage(message);
         return { signature, type: "CROSSMINT_ETHEREUM" };
     }

--- a/packages/extension/src/ExtensionSigner.ts
+++ b/packages/extension/src/ExtensionSigner.ts
@@ -1,4 +1,5 @@
 import { SignParameters, SignAndSendFunction, BaseSigner, TypedSignature, SignatureType, SignAndSendStrategy } from '@logion/client';
+import { ValidAccountId } from '@logion/node-api';
 import { web3FromAddress } from '@polkadot/extension-dapp';
 import { META_MASK_NAME } from "./Extension.js";
 
@@ -8,13 +9,13 @@ export class ExtensionSigner extends BaseSigner {
         super(signAndSendStrategy);
     }
 
-    async signToHex(signerId: string, message: string): Promise<TypedSignature> {
-        const extension = await web3FromAddress(signerId);
+    async signToHex(signerId: ValidAccountId, message: string): Promise<TypedSignature> {
+        const extension = await web3FromAddress(signerId.address);
         if(!extension.signer.signRaw) {
             throw new Error("Web3 extension does not support bytes signing");
         }
         const result = await extension.signer.signRaw({
-            address: signerId,
+            address: signerId.address,
             type: "bytes",
             data: message
         });

--- a/packages/node-api/test/__mocks__/PolkadotApiMock.ts
+++ b/packages/node-api/test/__mocks__/PolkadotApiMock.ts
@@ -52,6 +52,7 @@ export const DEFAULT_LOC: LegalOfficerCase = {
         address: "5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb",
         type: "Polkadot",
         toOtherAccountId: () => { throw new Error() },
+        toKey: () => "Polkadot:5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb",
     },
     metadata: [
         {


### PR DESCRIPTION
* Add account types encapsulating account validation and conveying address type
* Enable authentication with account of any type
* Not yet tested against new backend (not yet available) so will require further adjustments

https://github.com/logion-network/logion-internal/issues/852