### PR TITLE
Deprecate VerifiedIssuers module

### DIFF
--- a/packages/node-api/src/Adapters.ts
+++ b/packages/node-api/src/Adapters.ts
@@ -278,6 +278,10 @@ export class Adapters {
         return this.api.createType("Compact<u128>", id.toHexString());
     }
 
+    fromLocId(locId: u128): UUID {
+        return UUID.fromDecimalStringOrThrow(locId.toString());
+    }
+
     toLocFile(file: File): PalletLogionLocFile {
         return this.api.createType("PalletLogionLocFile", {
             hash_: file.hash,

--- a/packages/node-api/src/Connection.ts
+++ b/packages/node-api/src/Connection.ts
@@ -10,6 +10,9 @@ import { FeesEstimator } from './FeesEstimator.js';
 import { Queries } from './Queries.js';
 import { ChainTime } from './ChainTime.js';
 import { Vault } from './VaultClass.js';
+import { LocBatch } from './LocBatch.js';
+import { UUID } from './UUID.js';
+import { LegalOfficerCase, VerifiedIssuerType } from './Types.js';
 
 export type LogionNodeApi = ApiPromise;
 
@@ -54,6 +57,24 @@ export class LogionNodeApiClass {
 
     vault(requester: string, legalOfficers: string[]) {
         return new Vault(this.polkadot, requester, legalOfficers);
+    }
+
+    readonly batch = {
+        /**
+         * Builds a LocBatch instance.
+         * 
+         * @param ids The LOCs to consider.
+         * @param locs DEPRECATED - this parameter will be removed
+         * @param availableVerifiedIssuers DEPRECATED - this parameter will be removed
+         * @returns a LocBatch instance
+         */
+        locs: (ids: UUID[], locs?: Record<string, LegalOfficerCase>, availableVerifiedIssuers?: Record<string, VerifiedIssuerType[]>) => new LocBatch({
+            api: this.polkadot,
+            adapters: this.adapters,
+            locIds: ids,
+            locs,
+            availableVerifiedIssuers,
+        }),
     }
 }
 

--- a/packages/node-api/src/LocBatch.ts
+++ b/packages/node-api/src/LocBatch.ts
@@ -1,0 +1,146 @@
+import { ApiPromise } from "@polkadot/api";
+import { UUID } from "./UUID.js";
+import { Adapters } from "./Adapters.js";
+import { LegalOfficerCase, VerifiedIssuerType } from "./Types.js";
+
+/**
+ * Batches queries on LOCs and their associated Verified Issuers. Query results are cached.
+ * The object must be re-created in order to get fresh data.
+ */
+export class LocBatch {
+
+    constructor(args: {
+        /** Polkadot API */
+        api: ApiPromise,
+        /** logion adapters */
+        adapters: Adapters,
+        /** The IDs of the LOCs to consider */
+        locIds: UUID[],
+        /** DEPRECATED - a map of already fetched LOCs used to initialize the cache */
+        locs?: Record<string, LegalOfficerCase>,
+        /** DEPRECATED - a map of already fetched verified issuers per legal officer used to initialize the cache */
+        availableVerifiedIssuers?: Record<string, VerifiedIssuerType[]>,
+    }) {
+        this.api = args.api;
+        this.adapters = args.adapters;
+        this.locIds = args.locIds;
+
+        this.locs = args.locs;
+        this.availableVerifiedIssuers = args.availableVerifiedIssuers;
+    }
+
+    private api: ApiPromise;
+    private adapters: Adapters;
+    private locIds: UUID[];
+
+    async getLocsVerifiedIssuers(): Promise<Record<string, VerifiedIssuerType[]>> {
+        this.locsVerifiedIssuers ||= await this.computeLocsVerifiedIssuers();
+        return this.locsVerifiedIssuers;
+    }
+
+    private locsVerifiedIssuers: Record<string, VerifiedIssuerType[]> | undefined;
+
+    private async computeLocsVerifiedIssuers(): Promise<Record<string, VerifiedIssuerType[]>> {
+        const availableVerifiedIssuers = await this.getAvailableVerifiedIssuers();
+        const potentialIssuers = Object.values(availableVerifiedIssuers).flatMap(issuer => issuer).map(issuer => issuer.address);
+        if(potentialIssuers.length === 0) {
+            const map: Record<string, VerifiedIssuerType[]> = {};
+            this.locIds.forEach(id => {
+                map[id.toDecimalString()] = [];
+            });
+            return map;
+        }
+    
+        const keys: [string, string][] = [];
+        this.locIds.forEach(id => {
+            potentialIssuers.forEach(issuer => {
+                keys.push([ id.toDecimalString(), issuer ]);
+            });
+        });
+    
+        const locs = await this.getLocs();
+        const entries = await this.api.query.logionLoc.verifiedIssuersByLocMap.multi(keys);
+        const map: Record<string, VerifiedIssuerType[]> = {};
+        for(let i = 0; i < keys.length; ++i) {
+            const locId = keys[i][0];
+            const verifiedIssuers: VerifiedIssuerType[] = map[locId] ||= [];
+            if(entries[i].isSome) {
+                const verifiedIssuerAddress = keys[i][1];
+                const owner = locs[locId].owner;
+                const verifiedIssuer = availableVerifiedIssuers[owner].find(issuer => issuer.address === verifiedIssuerAddress);
+                if(!verifiedIssuer) {
+                    throw new Error("Verified issuer not found");
+                }
+                verifiedIssuers.push(verifiedIssuer);
+            }
+        }
+        return map;
+    }
+
+    private async getAvailableVerifiedIssuers(): Promise<Record<string, VerifiedIssuerType[]>> {
+        this.availableVerifiedIssuers ||= await this.computeAvailableVerifiedIssuersMap();
+        return this.availableVerifiedIssuers;
+    }
+
+    private availableVerifiedIssuers: Record<string, VerifiedIssuerType[]> | undefined;
+
+    private async computeAvailableVerifiedIssuersMap(): Promise<Record<string, VerifiedIssuerType[]>> {
+        const locs = await this.getLocs();
+        const legalOfficerAddresses = Object.values(locs).map(loc => loc.owner);
+
+        const map: Record<string, VerifiedIssuerType[]> = {};
+        for(const legalOfficerAddress of legalOfficerAddresses) {
+            if(!(legalOfficerAddress in map)) {
+                const mapEntry: VerifiedIssuerType[] = [];
+                map[legalOfficerAddress] = mapEntry;
+    
+                const entries = await this.api.query.logionLoc.verifiedIssuersMap.entries(legalOfficerAddress);
+                for(const entry of entries) {
+                    const address = entry[0].args[1].toString();
+                    const issuerOption = entry[1];
+                    const identityLocId = this.adapters.fromLocId(issuerOption.unwrap().identityLoc);
+    
+                    mapEntry.push({
+                        address,
+                        identityLocId,
+                    });
+                }
+            }
+        }
+        return map;
+    }
+
+    async getLocs(): Promise<Record<string, LegalOfficerCase>> {
+        this.locs ||= await this.computeLocs(this.locIds);
+        return this.locs;
+    }
+
+    private locs: Record<string, LegalOfficerCase> | undefined;
+
+    private async computeLocs(locIds: UUID[]): Promise<Record<string, LegalOfficerCase>> {
+        const locs = await this.computeLocsArray(locIds);
+        const map: Record<string, LegalOfficerCase> = {};
+        for(let i = 0; i < locs.length; ++i) {
+            const loc = locs[i];
+            const locId = locIds[i];
+            if(loc !== undefined) {
+                map[locId.toDecimalString()] = loc;
+            }
+        }
+        return map;
+    }
+
+    private async computeLocsArray(locIds: UUID[]): Promise<(LegalOfficerCase | undefined)[]> {
+        const result = await this.api.query.logionLoc.locMap.multi(locIds.map(id => id.toHexString()));
+        const locs: (LegalOfficerCase | undefined)[] = [];
+        for(let i = 0; i < result.length; ++i) {
+            const option = result[i];
+            if(option.isSome) {
+                locs.push(this.adapters.fromPalletLogionLocLegalOfficerCase(option.unwrap()));
+            } else {
+                locs.push(undefined);
+            }
+        }
+        return locs;
+    }
+}

--- a/packages/node-api/src/LogionLoc.ts
+++ b/packages/node-api/src/LogionLoc.ts
@@ -170,19 +170,19 @@ export interface GetLegalOfficerCasesParameters {
 }
 
 /**
- * @deprecated use logionApi.queries.getLegalOfficerCases(locIds)
+ * @deprecated use logionApi.batch.locs(locIds).getLocs()
  */
 export async function getLegalOfficerCases(parameters: GetLegalOfficerCasesParameters): Promise<(LegalOfficerCase | undefined)[]> {
     const logionApi = new LogionNodeApiClass(parameters.api);
-    return logionApi.queries.getLegalOfficerCases(parameters.locIds);
+    return Object.values(await logionApi.batch.locs(parameters.locIds).getLocs());
 }
 
 /**
- * @deprecated use logionApi.queries.getLegalOfficerCasesMap(locIds)
+ * @deprecated use logionApi.batch.locs(locIds).getLocs()
  */
 export async function getLegalOfficerCasesMap(parameters: GetLegalOfficerCasesParameters): Promise<Record<string, LegalOfficerCase>> {
     const logionApi = new LogionNodeApiClass(parameters.api);
-    return logionApi.queries.getLegalOfficerCasesMap(parameters.locIds);
+    return await logionApi.batch.locs(parameters.locIds).getLocs();
 }
 
 /**

--- a/packages/node-api/src/Queries.ts
+++ b/packages/node-api/src/Queries.ts
@@ -124,33 +124,6 @@ export class Queries {
         }
     }
 
-    async getLegalOfficerCases(locIds: UUID[]): Promise<(LegalOfficerCase | undefined)[]> {
-        const result = await this.api.query.logionLoc.locMap.multi(locIds.map(id => id.toHexString()));
-        const locs: (LegalOfficerCase | undefined)[] = [];
-        for(let i = 0; i < result.length; ++i) {
-            const option = result[i];
-            if(option.isSome) {
-                locs.push(this.adapters.fromPalletLogionLocLegalOfficerCase(option.unwrap()));
-            } else {
-                locs.push(undefined);
-            }
-        }
-        return locs;
-    }
-
-    async getLegalOfficerCasesMap(locIds: UUID[]): Promise<Record<string, LegalOfficerCase>> {
-        const locs = await this.getLegalOfficerCases(locIds);
-        const map: Record<string, LegalOfficerCase> = {};
-        for(let i = 0; i < locs.length; ++i) {
-            const loc = locs[i];
-            const locId = locIds[i];
-            if(loc !== undefined) {
-                map[locId.toDecimalString()] = loc;
-            }
-        }
-        return map;
-    }
-
     async getCollectionItem(locId: UUID, itemId: string): Promise<CollectionItem | undefined> {
         const result = await this.api.query.logionLoc.collectionItemsMap(Adapters.toLocId(locId), itemId);
         if(result.isSome) {

--- a/packages/node-api/src/Types.ts
+++ b/packages/node-api/src/Types.ts
@@ -268,3 +268,8 @@ export interface Sponsorship {
     legalOfficer: AccountId;
     locId: UUID | undefined;
 }
+
+export interface VerifiedIssuerType {
+    address: string;
+    identityLocId: UUID;
+}

--- a/packages/node-api/src/VerifiedIssuers.ts
+++ b/packages/node-api/src/VerifiedIssuers.ts
@@ -1,95 +1,49 @@
-import { LogionNodeApi } from "./Connection.js";
-import { getLegalOfficerCase } from "./LogionLoc.js";
-import { LegalOfficerCase } from "./Types.js";
+import { LogionNodeApi, LogionNodeApiClass } from "./Connection.js";
+import { LegalOfficerCase, VerifiedIssuerType } from "./Types.js";
 import { UUID } from "./UUID.js";
 
-export interface VerifiedIssuer {
-    address: string;
-    identityLocId: UUID;
-}
+/**
+ * @deprecated use VerifiedIssuerType
+ */
+export type VerifiedIssuer = VerifiedIssuerType;
 
+/**
+ * @deprecated use (await logionApi.batch.locs([ locId ]).getLocsVerifiedIssuers())[ locId.toDecimalString() ]
+ */
 export async function getVerifiedIssuers(
     api: LogionNodeApi,
     locId: UUID,
     locs?: Record<string, LegalOfficerCase>,
     availableVerifiedIssuers?: Record<string, VerifiedIssuer[]>,
 ): Promise<VerifiedIssuer[]> {
-    const loc = locs ? locs[locId.toDecimalString()] : await getLegalOfficerCase({
-        api,
-        locId,
-    });
-    if(!loc) {
-        throw new Error("LOC not found");
-    }
-    const owner = loc.owner;
-    const entries = await api.query.logionLoc.verifiedIssuersByLocMap.entries(locId.toDecimalString());
-    const verifiedIssuers: VerifiedIssuer[] = [];
-    for(const entry of entries) {
-        const verifiedIssuerAddress = entry[0].args[1].toString();
-
-        let verifiedIssuer: VerifiedIssuer | undefined;
-        if(availableVerifiedIssuers && owner in availableVerifiedIssuers) {
-            verifiedIssuer = availableVerifiedIssuers[owner].find(issuer => issuer.address === verifiedIssuerAddress);
-        } else {
-            const issuerOption = await api.query.logionLoc.verifiedIssuersMap(owner, verifiedIssuerAddress);
-            const identityLocId = UUID.fromDecimalStringOrThrow(issuerOption.unwrap().identityLoc.toString());
-            verifiedIssuer = {
-                address: verifiedIssuerAddress,
-                identityLocId,
-            };
-        }
-        if(verifiedIssuer) {
-            verifiedIssuers.push(verifiedIssuer);
-        }
-    }
-    return verifiedIssuers;
+    const logionApi = new LogionNodeApiClass(api);
+    return (await logionApi.batch.locs([ locId ], locs, availableVerifiedIssuers).getLocsVerifiedIssuers())[locId.toDecimalString()];
 }
 
+/**
+ * @deprecated use logionApi.batch.locs(locIds).getLocsVerifiedIssuers()
+ */
 export async function getVerifiedIssuersBatch(
     api: LogionNodeApi,
     locIds: UUID[],
     locs: Record<string, LegalOfficerCase>,
     availableVerifiedIssuers: Record<string, VerifiedIssuer[]>,
 ): Promise<Record<string, VerifiedIssuer[]>> {
-    const potentialIssuers = Object.values(availableVerifiedIssuers).flatMap(issuer => issuer).map(issuer => issuer.address);
-    if(potentialIssuers.length === 0) {
-        const map: Record<string, VerifiedIssuer[]> = {};
-        locIds.forEach(id => {
-            map[id.toDecimalString()] = [];
-        });
-        return map;
-    }
-
-    const keys: [string, string][] = [];
-    locIds.forEach(id => {
-        potentialIssuers.forEach(issuer => {
-            keys.push([ id.toDecimalString(), issuer ]);
-        });
-    });
-
-    const entries = await api.query.logionLoc.verifiedIssuersByLocMap.multi(keys);
-    const map: Record<string, VerifiedIssuer[]> = {};
-    for(let i = 0; i < keys.length; ++i) {
-        const locId = keys[i][0];
-        const verifiedIssuers: VerifiedIssuer[] = map[locId] ||= [];
-        if(entries[i].isSome) {
-            const verifiedIssuerAddress = keys[i][1];
-            const owner = locs[locId].owner;
-            const verifiedIssuer = availableVerifiedIssuers[owner].find(issuer => issuer.address === verifiedIssuerAddress);
-            if(!verifiedIssuer) {
-                throw new Error("Verified issuer not found");
-            }
-            verifiedIssuers.push(verifiedIssuer);
-        }
-    }
-    return map;
+    const logionApi = new LogionNodeApiClass(api);
+    return logionApi.batch.locs(locIds, locs, availableVerifiedIssuers).getLocsVerifiedIssuers();
 }
 
+/**
+ * @deprecated this function has no replacement
+ */
 export async function getLegalOfficerVerifiedIssuers(api: LogionNodeApi, legalOfficerAddress: string): Promise<VerifiedIssuer[]> {
     const issuers = await getLegalOfficerVerifiedIssuersBatch(api, [legalOfficerAddress]);
     return issuers[legalOfficerAddress];
 }
 
+/**
+ * @deprecated this function has no replacement
+ */
 export async function getLegalOfficerVerifiedIssuersBatch(api: LogionNodeApi, legalOfficerAddresses: string[]): Promise<Record<string, VerifiedIssuer[]>> {
     const map: Record<string, VerifiedIssuer[]> = {};
     for(const legalOfficerAddress of legalOfficerAddresses) {

--- a/packages/node-api/src/index.ts
+++ b/packages/node-api/src/index.ts
@@ -17,3 +17,4 @@ export * from "./UUID.js";
 export * from "./Vault.js";
 export * from "./VaultClass.js";
 export * from "./VerifiedIssuers.js";
+export * from "./LocBatch.js";


### PR DESCRIPTION
* Logion API gets an additional `batch` section
* All LOC-related batch queries are handled by a new object which also acts as a data cache

logion-network/logion-internal#836