### PR TITLE
Refactor client given new node API

### DIFF
--- a/packages/client/integration/Fees.ts
+++ b/packages/client/integration/Fees.ts
@@ -3,8 +3,8 @@ import { State, REQUESTER_ADDRESS } from "./Utils.js";
 
 export async function fees(state: State) {
     const client = state.client;
-    const api = client.nodeApi;
-    const submittable = api.tx.balances.transfer(ALICE.address, "10000000");
+    const api = client.logionApi;
+    const submittable = api.polkadot.tx.balances.transfer(ALICE.address, "10000000");
     const fees = await client.public.fees.estimateWithoutStorage({ origin: REQUESTER_ADDRESS, submittable });
     expect(fees.totalFee).toBe(2629491440000000n);
 }

--- a/packages/client/integration/Protection.ts
+++ b/packages/client/integration/Protection.ts
@@ -1,4 +1,4 @@
-import { buildApi, UUID, ValidAccountId } from '@logion/node-api';
+import { buildApiClass, UUID, ValidAccountId } from '@logion/node-api';
 
 import {
     LogionClient,
@@ -175,15 +175,18 @@ async function createAndCloseIdentityLoc(
     legalOfficerAddress: string,
     requesterAddress: string
 ): Promise<UUID> {
-    const api = await buildApi(config.rpcEndpoints);
+    const api = await buildApiClass(config.rpcEndpoints);
     const identityLocId = new UUID();
     await signer.signAndSend({
         signerId: legalOfficerAddress,
-        submittable: api.tx.logionLoc.createPolkadotIdentityLoc(identityLocId.toDecimalString(), requesterAddress)
+        submittable: api.polkadot.tx.logionLoc.createPolkadotIdentityLoc(
+            api.adapters.toLocId(identityLocId),
+            requesterAddress
+        )
     });
     await signer.signAndSend({
         signerId: legalOfficerAddress,
-        submittable: api.tx.logionLoc.close(identityLocId.toDecimalString())
+        submittable: api.polkadot.tx.logionLoc.close(api.adapters.toLocId(identityLocId))
     });
     return identityLocId;
 }

--- a/packages/client/integration/Recovery.ts
+++ b/packages/client/integration/Recovery.ts
@@ -1,4 +1,4 @@
-import { ValidAccountId, buildApi } from "@logion/node-api";
+import { ValidAccountId, buildApiClass } from "@logion/node-api";
 
 import {
     AcceptedProtection,
@@ -67,7 +67,7 @@ export async function recoverLostAccount(state: State) {
     const pendingRequest = recoveredVault.pendingVaultTransferRequests[0];
 
     console.log("Alice accepts transfer from recovered vault")
-    await aliceAcceptsTransfer(state, pendingRequest);
+    await aliceAcceptsTransfer(state, pendingRequest, claimed);
 
     console.log("Transfer from recovered account")
     const recoveredBalance = await claimed.recoveredBalanceState();
@@ -133,9 +133,9 @@ async function vouchRecovery(
     lost: string,
     rescuer: string,
 ): Promise<void> {
-    const api = await buildApi(config.rpcEndpoints);
+    const api = await buildApiClass(config.rpcEndpoints);
     await signer.signAndSend({
         signerId: legalOfficerAddress.address,
-        submittable: api.tx.recovery.vouchRecovery(lost, rescuer)
+        submittable: api.polkadot.tx.recovery.vouchRecovery(lost, rescuer)
     })
 }

--- a/packages/client/src/AuthenticationClient.ts
+++ b/packages/client/src/AuthenticationClient.ts
@@ -1,4 +1,4 @@
-import { LogionNodeApi, ValidAccountId } from "@logion/node-api";
+import { LogionNodeApiClass, ValidAccountId } from "@logion/node-api";
 import { AxiosInstance } from "axios";
 import { DateTime } from "luxon";
 import { AxiosFactory } from "./AxiosFactory";
@@ -18,14 +18,14 @@ type AuthenticationResponse = Record<string, { value: string, expiredOn: string 
 
 export class AuthenticationClient {
 
-    constructor(api: LogionNodeApi, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) {
+    constructor(api: LogionNodeApiClass, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) {
         this.api = api;
         this.directoryEndpoint = directoryEndpoint;
         this.legalOfficers = legalOfficers;
         this.axiosFactory = axiosFactory;
     }
 
-    private api: LogionNodeApi;
+    private api: LogionNodeApiClass;
 
     private directoryEndpoint: string;
 
@@ -127,12 +127,12 @@ export class AuthenticationClient {
 
 export class AccountTokens {
 
-    constructor(api: LogionNodeApi, initialState: Record<string, Token>) {
+    constructor(api: LogionNodeApiClass, initialState: Record<string, Token>) {
         this.api = api;
         this.store = { ...initialState };
     }
 
-    private api: LogionNodeApi;
+    private api: LogionNodeApiClass;
 
     private store: Record<string, Token>;
 
@@ -149,7 +149,7 @@ export class AccountTokens {
     }
 
     get addresses(): ValidAccountId[] {
-        return Object.keys(this.store).map(key => ValidAccountId.parseKey(this.api, key));
+        return Object.keys(this.store).map(key => ValidAccountId.parseKey(this.api.polkadot, key));
     }
 
     cleanUp(now: DateTime): AccountTokens {

--- a/packages/client/src/ComponentFactory.ts
+++ b/packages/client/src/ComponentFactory.ts
@@ -1,4 +1,4 @@
-import { LogionNodeApi, buildApi } from "@logion/node-api";
+import { LogionNodeApiClass, buildApiClass } from "@logion/node-api";
 import { AuthenticationClient } from "./AuthenticationClient.js";
 import { AxiosFactory } from "./AxiosFactory.js";
 import { DirectoryClient } from "./DirectoryClient.js";
@@ -17,17 +17,17 @@ export type UploadableData = File | Blob | Buffer | NodeJS.ReadableStream;
 export interface ComponentFactory {
     buildAxiosFactory: () => AxiosFactory;
     buildDirectoryClient: (directoryEndpoint: string, axiosFactory: AxiosFactory, token?: string) => DirectoryClient;
-    buildAuthenticationClient: (api: LogionNodeApi, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => AuthenticationClient;
+    buildAuthenticationClient: (api: LogionNodeApiClass, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => AuthenticationClient;
     buildNetworkState(nodesUp: LegalOfficerEndpoint[], nodesDown: LegalOfficerEndpoint[]): NetworkState<LegalOfficerEndpoint>;
-    buildNodeApi(rpcEndpoints: string[]): Promise<LogionNodeApi>;
+    buildNodeApi(rpcEndpoints: string[]): Promise<LogionNodeApiClass>;
     buildFormData: () => FormDataLike;
 }
 
 export const DefaultComponentFactory: ComponentFactory = {
     buildAxiosFactory: () => new AxiosFactory(),
     buildDirectoryClient: (directoryEndpoint: string, axiosFactory: AxiosFactory, token?: string) => new DirectoryClient(directoryEndpoint, axiosFactory, token),
-    buildAuthenticationClient: (api: LogionNodeApi, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => new AuthenticationClient(api, directoryEndpoint, legalOfficers, axiosFactory),
+    buildAuthenticationClient: (api: LogionNodeApiClass, directoryEndpoint: string, legalOfficers: LegalOfficerClass[], axiosFactory: AxiosFactory) => new AuthenticationClient(api, directoryEndpoint, legalOfficers, axiosFactory),
     buildNetworkState: (nodesUp: LegalOfficerEndpoint[], nodesDown: LegalOfficerEndpoint[]) => new NetworkState(nodesUp, nodesDown),
-    buildNodeApi: (rpcEndpoints: string[]) => buildApi(rpcEndpoints),
+    buildNodeApi: (rpcEndpoints: string[]) => buildApiClass(rpcEndpoints),
     buildFormData: () => new FormData(),
 };

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -1,32 +1,20 @@
 import {
-    LogionNodeApi,
+    LogionNodeApiClass,
     UUID,
     Link,
     LocType,
     LegalOfficerCase,
     ItemFile,
-    getLegalOfficerCase,
-    addCollectionItem,
-    getCollectionItem,
-    getCollectionSize,
-    GetLegalOfficerCaseParameters,
-    getCollectionItems,
     CollectionItem,
     TermsAndConditionsElement as ChainTermsAndConditionsElement,
-    getVerifiedIssuers,
-    newTokensRecordFiles,
-    TokensRecordFile,
-    toTokensRecord,
-    TokensRecord as ChainTokensRecord,
-    getLegalOfficerCasesMap,
-    VerifiedIssuer,
-    getLegalOfficerVerifiedIssuersBatch,
-    getVerifiedIssuersBatch,
     ValidAccountId,
-    AccountType
+    AccountType,
+    LocBatch,
+    Adapters,
+    TypesTokensRecord,
+    TypesTokensRecordFile
 } from '@logion/node-api';
-import { Option } from "@polkadot/types-codec";
-import { PalletLogionLocVerifiedIssuer } from "@polkadot/types/lookup";
+import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { AxiosInstance } from 'axios';
 
 import { UserIdentity, LegalOfficer, PostalAddress, LegalOfficerClass } from "./Types.js";
@@ -334,7 +322,7 @@ export class LocMultiClient {
         axiosFactory: AxiosFactory,
         currentAddress: ValidAccountId,
         token: string,
-        nodeApi: LogionNodeApi,
+        nodeApi: LogionNodeApiClass,
         componentFactory: ComponentFactory,
     }) {
         this.networkState = params.networkState;
@@ -353,7 +341,7 @@ export class LocMultiClient {
 
     private readonly token: string;
 
-    private readonly nodeApi: LogionNodeApi;
+    private readonly nodeApi: LogionNodeApiClass;
 
     private readonly componentFactory: ComponentFactory;
 
@@ -395,7 +383,7 @@ export class LocMultiClient {
         if (this.currentAddress.type !== "Polkadot") {
             return [];
         }
-        const entries = await this.nodeApi.query.logionLoc.locsByVerifiedIssuerMap.entries(this.currentAddress.address);
+        const entries = await this.nodeApi.polkadot.query.logionLoc.locsByVerifiedIssuerMap.entries(this.currentAddress.address);
         const requests: LocRequest[] = [];
         for(const entry of entries) {
             const owner = entry[0].args[1].toString();
@@ -414,29 +402,20 @@ export class LocMultiClient {
         });
     }
 
-    static async getLoc(params: GetLegalOfficerCaseParameters): Promise<LegalOfficerCase> {
+    static async getLoc(params: { api: LogionNodeApiClass, locId: UUID }): Promise<LegalOfficerCase> {
         return requireDefined(
-            await getLegalOfficerCase(params),
+            await params.api.queries.getLegalOfficerCase(params.locId),
             () => new Error(`LOC not found on chain: ${ params.locId.toDecimalString() }`)
         );
     }
 
-    static async getLocs(params: { api: LogionNodeApi, locIds: UUID[] }): Promise<Record<string, LegalOfficerCase>> {
+    static async getLocBatch(params: { api: LogionNodeApiClass, locIds: UUID[] }): Promise<LocBatch> {
         const { api, locIds } = params;
-        return getLegalOfficerCasesMap({ api, locIds });
+        return api.batch.locs(locIds);
     }
 
-    async getLocs(params: { locIds: UUID[] }): Promise<Record<string, LegalOfficerCase>> {
-        return LocMultiClient.getLocs({ ...params, api: this.nodeApi });
-    }
-
-    async getLegalOfficersVerifiedIssuers(legalOfficerAddresses: string[]): Promise<Record<string, VerifiedIssuer[]>> {
-        return getLegalOfficerVerifiedIssuersBatch(this.nodeApi, legalOfficerAddresses);
-    }
-
-    async getSelectedVerifiedIssuers(params: { locIds: UUID[], locs: Record<string, LegalOfficerCase>, availableVerifiedIssuers: Record<string, VerifiedIssuer[]> }): Promise<Record<string, VerifiedIssuer[]>> {
-        const { locIds, locs, availableVerifiedIssuers } = params;
-        return getVerifiedIssuersBatch(this.nodeApi, locIds, locs, availableVerifiedIssuers);
+    async getLocBatch(locIds: UUID[]): Promise<LocBatch> {
+        return LocMultiClient.getLocBatch({ api: this.nodeApi, locIds });
     }
 }
 
@@ -480,7 +459,7 @@ export abstract class LocClient {
 
     constructor(params: {
         axiosFactory: AxiosFactory,
-        nodeApi: LogionNodeApi,
+        nodeApi: LogionNodeApiClass,
         legalOfficer: LegalOfficerClass,
     }) {
         this.axiosFactory = params.axiosFactory;
@@ -489,7 +468,7 @@ export abstract class LocClient {
     }
 
     protected readonly axiosFactory: AxiosFactory;
-    protected readonly nodeApi: LogionNodeApi;
+    protected readonly nodeApi: LogionNodeApiClass;
     protected readonly legalOfficer: LegalOfficerClass;
 
     async getLoc(parameters: FetchParameters): Promise<LegalOfficerCase> {
@@ -502,11 +481,7 @@ export abstract class LocClient {
 
     async getCollectionItem(parameters: { itemId: string } & FetchParameters): Promise<UploadableCollectionItem | undefined> {
         const { locId, itemId } = parameters;
-        const onchainItem = await getCollectionItem({
-            api: this.nodeApi,
-            locId,
-            itemId
-        });
+        const onchainItem = await this.nodeApi.queries.getCollectionItem(locId, itemId);
         if(!onchainItem) {
             return undefined;
         }
@@ -544,10 +519,7 @@ export abstract class LocClient {
 
     async getCollectionItems(parameters: FetchParameters): Promise<UploadableCollectionItem[]> {
         const { locId } = parameters;
-        const onchainItems = await getCollectionItems({
-            api: this.nodeApi,
-            locId,
-        });
+        const onchainItems = await this.nodeApi.queries.getCollectionItems(locId);
 
         const onchainItemsMap: Record<string, CollectionItem> = {};
         for(const item of onchainItems) {
@@ -576,21 +548,18 @@ export abstract class LocClient {
 
     async getCollectionSize(parameters: FetchParameters): Promise<number | undefined> {
         const { locId } = parameters;
-        return await getCollectionSize({
-            api: this.nodeApi,
-            locId,
-        });
+        return await this.nodeApi.queries.getCollectionSize(locId);
     }
 
     async getTokensRecord(parameters: { recordId: string } & FetchParameters): Promise<ClientTokensRecord | undefined> {
         const { locId, recordId } = parameters;
-        const onchainRecord = await this.nodeApi.query.logionLoc.tokensRecordsMap(locId.toDecimalString(), recordId);
+        const onchainRecord = await this.nodeApi.polkadot.query.logionLoc.tokensRecordsMap(locId.toDecimalString(), recordId);
         if(onchainRecord.isNone) {
             return undefined;
         }
         try {
             const offchainRecord = await this.getOffchainRecord({ locId, recordId });
-            return this.mergeRecords(toTokensRecord(onchainRecord.unwrap()), offchainRecord);
+            return this.mergeRecords(Adapters.toTokensRecord(onchainRecord.unwrap()), offchainRecord);
         } catch(e) {
             throw newBackendError(e);
         }
@@ -602,7 +571,7 @@ export abstract class LocClient {
         return response.data;
     }
 
-    private mergeRecords(onchainItem: ChainTokensRecord, offchainItem: OffchainTokensRecord): ClientTokensRecord {
+    private mergeRecords(onchainItem: TypesTokensRecord, offchainItem: OffchainTokensRecord): ClientTokensRecord {
         return {
             id: offchainItem.recordId,
             description: onchainItem.description,
@@ -618,11 +587,11 @@ export abstract class LocClient {
 
     async getTokensRecords(parameters: GetTokensRecordsRequest): Promise<ClientTokensRecord[]> {
         const { locId } = parameters;
-        const onchainRecords = await this.nodeApi.query.logionLoc.tokensRecordsMap.entries(locId.toDecimalString());
+        const onchainRecords = await this.nodeApi.polkadot.query.logionLoc.tokensRecordsMap.entries(locId.toDecimalString());
 
-        const onchainRecordsMap: Record<string, ChainTokensRecord> = {};
+        const onchainRecordsMap: Record<string, TypesTokensRecord> = {};
         for(const entry of onchainRecords) {
-            onchainRecordsMap[entry[0].args[1].toHex()] = toTokensRecord(entry[1].unwrap());
+            onchainRecordsMap[entry[0].args[1].toHex()] = Adapters.toTokensRecord(entry[1].unwrap());
         }
 
         try {
@@ -709,7 +678,7 @@ export class AuthenticatedLocClient extends LocClient {
     constructor(params: {
         axiosFactory: AxiosFactory,
         currentAddress: ValidAccountId,
-        nodeApi: LogionNodeApi,
+        nodeApi: LogionNodeApiClass,
         legalOfficer: LegalOfficerClass,
         componentFactory: ComponentFactory,
     }) {
@@ -861,16 +830,27 @@ export class AuthenticatedLocClient extends LocClient {
             parameters.specificLicenses.forEach(addTC);
         }
 
-        const submittable = addCollectionItem({
-            api: this.nodeApi,
-            collectionId: locId,
-            itemId,
-            itemDescription,
-            itemFiles: chainItemFiles,
-            itemToken,
-            restrictedDelivery: booleanRestrictedDelivery,
-            termsAndConditions,
-        });
+        let submittable: SubmittableExtrinsic;
+        if(termsAndConditions.length === 0) {
+            submittable = this.nodeApi.polkadot.tx.logionLoc.addCollectionItem(
+                this.nodeApi.adapters.toLocId(locId),
+                itemId,
+                itemDescription,
+                chainItemFiles.map(Adapters.toCollectionItemFile),
+                Adapters.toCollectionItemToken(itemToken),
+                booleanRestrictedDelivery,
+            );
+        } else {
+            submittable = this.nodeApi.polkadot.tx.logionLoc.addCollectionItemWithTermsAndConditions(
+                this.nodeApi.adapters.toLocId(locId),
+                itemId,
+                itemDescription,
+                chainItemFiles.map(Adapters.toCollectionItemFile),
+                Adapters.toCollectionItemToken(itemToken),
+                booleanRestrictedDelivery,
+                termsAndConditions.map(Adapters.toTermsAndConditionsElement),
+            );
+        }
         await signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable,
@@ -962,9 +942,7 @@ export class AuthenticatedLocClient extends LocClient {
 
     async getLocIssuers(
         request: LocRequest,
-        locs?: Record<string, LegalOfficerCase>,
-        availableVerifiedIssuers?: Record<string, VerifiedIssuer[]>,
-        selectedIssuers?: Record<string, VerifiedIssuer[]>,
+        locBatch: LocBatch,
     ): Promise<LocVerifiedIssuers> {
         if(!this.currentAddress || (request.status !== "OPEN" && request.status !== "CLOSED")) {
             return EMPTY_LOC_ISSUERS;
@@ -972,14 +950,10 @@ export class AuthenticatedLocClient extends LocClient {
             const locId = new UUID(request.id);
             let verifiedThirdParty = false;
             if(request.locType === "Identity" && request.status === "CLOSED") {
-                if(availableVerifiedIssuers) {
-                    verifiedThirdParty = availableVerifiedIssuers[request.ownerAddress].find(issuer => issuer.address === request.requesterAddress?.address && request.requesterAddress?.type === "Polkadot") !== undefined;
-                } else if(request.requesterAddress?.type === "Polkadot") {
-                    const maybeIssuer = await this.nodeApi.query.logionLoc.verifiedIssuersMap(request.ownerAddress, request.requesterAddress?.address) as Option<PalletLogionLocVerifiedIssuer>;
-                    verifiedThirdParty = maybeIssuer.isSome;
-                }
+                const availableVerifiedIssuers = await locBatch.getAvailableVerifiedIssuers();
+                verifiedThirdParty = availableVerifiedIssuers[request.ownerAddress].find(issuer => issuer.address === request.requesterAddress?.address && request.requesterAddress?.type === "Polkadot") !== undefined;
             }
-            const nodeIssuers = selectedIssuers ? selectedIssuers[locId.toDecimalString()] : await getVerifiedIssuers(this.nodeApi, locId, locs, availableVerifiedIssuers);
+            const nodeIssuers = (await locBatch.getLocsVerifiedIssuers())[locId.toDecimalString()];
             const chainSelectedIssuers = new Set<string>();
             nodeIssuers.forEach(issuer => chainSelectedIssuers.add(issuer.address));
 
@@ -1035,7 +1009,7 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     private async isIssuerOf(request: LocRequest): Promise<boolean> {
-        const issuers = await this.getLocIssuers(request);
+        const issuers = await this.getLocIssuers(request, this.nodeApi.batch.locs([ new UUID(request.id) ]));
         return issuers.issuers.find(issuer => issuer.address === this.currentAddress.address && this.currentAddress.type === "Polkadot") !== undefined;
     }
 
@@ -1049,7 +1023,7 @@ export class AuthenticatedLocClient extends LocClient {
             files,
         } = parameters;
 
-        const chainItemFiles: TokensRecordFile[] = [];
+        const chainItemFiles: TypesTokensRecordFile[] = [];
         for(const itemFile of files) {
             await itemFile.finalize(); // Ensure hash and size
         }
@@ -1062,11 +1036,11 @@ export class AuthenticatedLocClient extends LocClient {
             });
         }
 
-        const submittable = this.nodeApi.tx.logionLoc.addTokensRecord(
-            locId.toDecimalString(),
+        const submittable = this.nodeApi.polkadot.tx.logionLoc.addTokensRecord(
+            this.nodeApi.adapters.toLocId(locId),
             recordId,
             description,
-            newTokensRecordFiles(this.nodeApi, chainItemFiles),
+            this.nodeApi.adapters.newTokensRecordFileVec(chainItemFiles),
         );
         await signer.signAndSend({
             signerId: this.currentAddress.address,

--- a/packages/client/src/Public.ts
+++ b/packages/client/src/Public.ts
@@ -1,4 +1,4 @@
-import { LegalOfficerCase, UUID, FeesEstimator, Adapters } from "@logion/node-api";
+import { LegalOfficerCase, UUID, FeesEstimator } from "@logion/node-api";
 
 import { CollectionItem } from "./CollectionItem.js";
 import { CheckCertifiedCopyResult, CheckResultType } from "./Deliveries.js";
@@ -20,7 +20,7 @@ export class PublicApi {
         sharedState: SharedState
     }) {
         this.sharedState = args.sharedState;
-        this.fees = new FeesEstimator(args.sharedState.nodeApi, new Adapters(args.sharedState.nodeApi));
+        this.fees = args.sharedState.nodeApi.fees;
     }
 
     private sharedState: SharedState;

--- a/packages/client/src/RecoveryClient.ts
+++ b/packages/client/src/RecoveryClient.ts
@@ -1,4 +1,4 @@
-import { LogionNodeApi, getProxy, getRecoveryConfig, RecoveryConfig } from "@logion/node-api";
+import { LogionNodeApiClass, TypesRecoveryConfig } from "@logion/node-api";
 import { AxiosInstance } from "axios";
 
 import { AxiosFactory } from "./AxiosFactory.js";
@@ -59,7 +59,7 @@ export interface FetchAllResult {
     acceptedProtectionRequests: ProtectionRequest[];
     rejectedProtectionRequests: ProtectionRequest[];
     cancelledProtectionRequests: ProtectionRequest[];
-    recoveryConfig: RecoveryConfig | undefined;
+    recoveryConfig: TypesRecoveryConfig | undefined;
     recoveredAddress: string | undefined;
 }
 
@@ -78,7 +78,7 @@ export class RecoveryClient {
         axiosFactory: AxiosFactory,
         currentAddress: string,
         token: string,
-        nodeApi: LogionNodeApi,
+        nodeApi: LogionNodeApiClass,
     }) {
         this.networkState = params.networkState;
         this.axiosFactory = params.axiosFactory;
@@ -95,7 +95,7 @@ export class RecoveryClient {
 
     private readonly token: string;
 
-    private readonly nodeApi: LogionNodeApi;
+    private readonly nodeApi: LogionNodeApiClass;
 
     async fetchAll(legalOfficers?: LegalOfficer[]): Promise<FetchAllResult> {
         const initialState = initMultiSourceHttpClientState(this.networkState, legalOfficers);
@@ -124,16 +124,8 @@ export class RecoveryClient {
             });
         }
 
-        const api = this.nodeApi;
-        const recoveryConfig = await getRecoveryConfig({
-            api,
-            accountId: this.currentAddress
-        });
-
-        const recoveredAddress = await getProxy({
-            api,
-            currentAddress: this.currentAddress
-        });
+        const recoveryConfig = await this.nodeApi.queries.getRecoveryConfig(this.currentAddress);
+        const recoveredAddress = await this.nodeApi.queries.getProxy(this.currentAddress);
 
         return {
             pendingProtectionRequests,

--- a/packages/client/src/SharedClient.ts
+++ b/packages/client/src/SharedClient.ts
@@ -1,4 +1,4 @@
-import { LogionNodeApi, ValidAccountId } from "@logion/node-api";
+import { LogionNodeApiClass, ValidAccountId } from "@logion/node-api";
 
 import { AccountTokens } from "./AuthenticationClient.js";
 import { AxiosFactory } from "./AxiosFactory.js";
@@ -25,7 +25,7 @@ export interface SharedState {
     axiosFactory: AxiosFactory;
     directoryClient: DirectoryClient;
     networkState: NetworkState<LegalOfficerEndpoint>;
-    nodeApi: LogionNodeApi;
+    nodeApi: LogionNodeApiClass;
     legalOfficers: LegalOfficerClass[];
     allLegalOfficers: LegalOfficerClass[];
     tokens: AccountTokens;

--- a/packages/client/src/Signer.ts
+++ b/packages/client/src/Signer.ts
@@ -1,12 +1,12 @@
-import { DateTime } from "luxon";
+import { TypesEvent, Adapters, ValidAccountId } from '@logion/node-api';
 import { Keyring } from '@polkadot/api';
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { ISubmittableResult } from '@polkadot/types/types';
-import { base64Encode } from '@polkadot/util-crypto';
 import { Registry } from '@polkadot/types-codec/types';
-import { toHex, getErrorMessage, Event, getExtrinsicEvents, ValidAccountId } from '@logion/node-api';
+import { base64Encode } from '@polkadot/util-crypto';
+import { stringToHex } from '@polkadot/util';
 import { Hash } from 'fast-sha256';
-
+import { DateTime } from "luxon";
 import { toIsoString } from "./DateTimeUtil.js";
 import { requireDefined } from "./assertions.js";
 
@@ -42,7 +42,7 @@ export interface SignParameters {
 export interface SuccessfulSubmission {
     readonly block: string;
     readonly index: number;
-    readonly events: Event[];
+    readonly events: TypesEvent[];
 }
 
 export interface Signer {
@@ -89,7 +89,7 @@ export abstract class BaseSigner implements FullSigner {
     abstract signToHex(signerId: ValidAccountId, message: string): Promise<TypedSignature>;
 
     buildMessage(parameters: SignRawParameters): string {
-        return toHex(hashAttributes(this.buildAttributes(parameters)));
+        return stringToHex(hashAttributes(this.buildAttributes(parameters)));
     }
 
     buildAttributes(parameters: SignRawParameters): string[] {
@@ -152,12 +152,12 @@ export abstract class BaseSigner implements FullSigner {
         if (params.result.dispatchError || params.signAndSendStrategy.canUnsub(params.result)) {
             params.unsub();
             if(params.result.dispatchError) {
-                params.reject(new Error(getErrorMessage(params.result.dispatchError)));
+                params.reject(new Error(Adapters.getErrorMessage(params.result.dispatchError)));
             } else {
                 params.resolve({
                     block: requireDefined(params.submissionState.block),
                     index: params.result.txIndex || -1,
-                    events: getExtrinsicEvents(params.result),
+                    events: Adapters.getExtrinsicEvents(params.result),
                 });
             }
         }

--- a/packages/client/src/Token.ts
+++ b/packages/client/src/Token.ts
@@ -1,4 +1,4 @@
-import { isValidAccountId, LogionNodeApi } from "@logion/node-api";
+import { LogionNodeApiClass } from "@logion/node-api";
 import { isHex } from "@polkadot/util";
 
 export interface ItemTokenWithRestrictedType {
@@ -61,7 +61,7 @@ export interface TokenValidationResult {
     error?: string;
 }
 
-export function validateToken(api: LogionNodeApi, itemToken: ItemTokenWithRestrictedType): TokenValidationResult {
+export function validateToken(api: LogionNodeApiClass, itemToken: ItemTokenWithRestrictedType): TokenValidationResult {
     if(isErcNft(itemToken.type)) {
         const { result, idObject } = validateErcToken(itemToken);
         if(result.valid) {
@@ -86,7 +86,7 @@ export function validateToken(api: LogionNodeApi, itemToken: ItemTokenWithRestri
     } else if(itemToken.type.includes("erc20")) {
         return validateErcToken(itemToken).result;
     } else if(itemToken.type === "owner") {
-        if(isHex(itemToken.id, ETHEREUM_ADDRESS_LENGTH_IN_BITS) || isValidAccountId(api, itemToken.id)) {
+        if(isHex(itemToken.id, ETHEREUM_ADDRESS_LENGTH_IN_BITS) || api.queries.isValidAccountId(itemToken.id)) {
             return { valid: true };
         } else {
             return {

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -3,6 +3,7 @@ export {
     ISubmittableResult,
 };
 
+export * from './assertions.js';
 export * from './AuthenticationClient.js';
 export * from './AxiosFactory.js';
 export * from './Balance.js';

--- a/packages/client/test/LogionClient.spec.ts
+++ b/packages/client/test/LogionClient.spec.ts
@@ -23,7 +23,7 @@ import {
     buildValidPolkadotAccountId,
     buildSimpleNodeApi
 } from './Utils.js';
-import { LogionNodeApi } from '@logion/node-api';
+import { LogionNodeApiClass } from '@logion/node-api';
 
 describe("LogionClient", () => {
 
@@ -49,7 +49,7 @@ describe("LogionClient", () => {
     it("uses tokens", async () => {
         const clientLegalOfficers: LegalOfficer[] = [ ALICE ];
         const token = 'token';
-        let api: Mock<LogionNodeApi>;
+        let api: Mock<LogionNodeApiClass>;
         const config = buildTestConfig(testConfigFactory => {
             testConfigFactory.setupDefaultAxiosInstanceFactory();
             testConfigFactory.setupDefaultNetworkState();

--- a/packages/client/test/Recovery.spec.ts
+++ b/packages/client/test/Recovery.spec.ts
@@ -1,6 +1,3 @@
-import type { Option, Vec } from '@polkadot/types-codec';
-import { PalletRecoveryActiveRecovery, PalletRecoveryRecoveryConfig } from "@polkadot/types/lookup";
-import type { AccountId } from '@polkadot/types/interfaces/runtime';
 import { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { DateTime } from 'luxon';
 import { It, Mock } from 'moq.ts';
@@ -22,15 +19,12 @@ import {
     UserIdentity,
     Signer,
     AccountTokens,
-    LegalOfficerClass
 } from '../src/index.js';
 import {
     ALICE,
     BOB,
     buildTestAuthenticatedSharedSate,
     LOGION_CLIENT_CONFIG,
-    mockOption,
-    mockEmptyOption,
     SUCCESSFUL_SUBMISSION,
     REQUESTER,
     RECOVERED_ADDRESS,
@@ -439,25 +433,14 @@ describe("NoProtection", () => {
                 factory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
 
                 const nodeApi = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-                nodeApi.setup(instance => instance.query.recovery.activeRecoveries(RECOVERED_ADDRESS.address, currentAddress.address))
-                    .returns(Promise.resolve(mockEmptyOption<PalletRecoveryActiveRecovery>()));
+                nodeApi.setup(instance => instance.queries.getActiveRecovery(RECOVERED_ADDRESS.address, currentAddress.address))
+                    .returns(Promise.resolve(undefined));
 
-                const aliceAccountId = new Mock<AccountId>();
-                aliceAccountId.setup(instance => instance.toString()).returns(ALICE.address);
-                const bobAccountId = new Mock<AccountId>();
-                bobAccountId.setup(instance => instance.toString()).returns(BOB.address);
-                const friends = new Mock<Vec<AccountId>>();
-                friends.setup(instance => instance.toArray()).returns([
-                    aliceAccountId.object(),
-                    bobAccountId.object()
-                ]);
-                nodeApi.setup(instance => instance.query.recovery.recoverable(RECOVERED_ADDRESS.address))
-                    .returns(Promise.resolve(mockOption<PalletRecoveryRecoveryConfig>({
-                        friends: friends.object()
-                    })));
+                nodeApi.setup(instance => instance.queries.getRecoveryConfig(RECOVERED_ADDRESS.address))
+                    .returns(Promise.resolve({ legalOfficers: [ ALICE.address, BOB.address ] }));
 
                 const submittable = new Mock<SubmittableExtrinsic>();
-                nodeApi.setup(instance => instance.tx.recovery.initiateRecovery(RECOVERED_ADDRESS.address))
+                nodeApi.setup(instance => instance.polkadot.tx.recovery.initiateRecovery(RECOVERED_ADDRESS.address))
                     .returns(submittable.object());
 
                 const axiosFactory = factory.setupAxiosFactoryMock();
@@ -567,10 +550,10 @@ describe("PendingProtection", () => {
                 factory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
 
                 const nodeApi = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-                nodeApi.setup(instance => instance.query.recovery.recoverable(currentAddress.address))
-                    .returns(Promise.resolve(mockEmptyOption<PalletRecoveryRecoveryConfig>()));
-                nodeApi.setup(instance => instance.query.recovery.proxy(currentAddress.address))
-                    .returns(Promise.resolve(mockEmptyOption<AccountId>()));
+                nodeApi.setup(instance => instance.queries.getRecoveryConfig(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
+                nodeApi.setup(instance => instance.queries.getProxy(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
             },
             currentAddress,
             legalOfficers,
@@ -620,10 +603,10 @@ describe("PendingProtection", () => {
                 factory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
 
                 const nodeApi = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-                nodeApi.setup(instance => instance.query.recovery.recoverable(currentAddress.address))
-                    .returns(Promise.resolve(mockEmptyOption<PalletRecoveryRecoveryConfig>()));
-                nodeApi.setup(instance => instance.query.recovery.proxy(currentAddress.address))
-                    .returns(Promise.resolve(mockEmptyOption<AccountId>()));
+                nodeApi.setup(instance => instance.queries.getRecoveryConfig(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
+                nodeApi.setup(instance => instance.queries.getProxy(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
             },
             currentAddress,
             legalOfficers,
@@ -708,13 +691,13 @@ describe("AcceptedProtection", () => {
                 factory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
 
                 const nodeApi = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-                nodeApi.setup(instance => instance.query.recovery.recoverable(currentAddress))
-                    .returns(Promise.resolve(mockEmptyOption<PalletRecoveryRecoveryConfig>()));
-                nodeApi.setup(instance => instance.query.recovery.proxy(currentAddress))
-                    .returns(Promise.resolve(mockEmptyOption<AccountId>()));
+                nodeApi.setup(instance => instance.queries.getRecoveryConfig(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
+                nodeApi.setup(instance => instance.queries.getProxy(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
 
                 const legalOfficersAddresses = legalOfficers.map(legalOfficer => legalOfficer.address);
-                nodeApi.setup(instance => instance.tx.verifiedRecovery.createRecovery(It.Is<string[]>(
+                nodeApi.setup(instance => instance.polkadot.tx.verifiedRecovery.createRecovery(It.Is<string[]>(
                         addresses => addresses.every(address => legalOfficersAddresses.includes(address)))))
                     .returns(submittable.object());
             },
@@ -771,13 +754,13 @@ describe("AcceptedProtection", () => {
                 factory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
 
                 const nodeApi = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-                nodeApi.setup(instance => instance.query.recovery.recoverable(currentAddress))
-                    .returns(Promise.resolve(mockEmptyOption<PalletRecoveryRecoveryConfig>()));
-                nodeApi.setup(instance => instance.query.recovery.proxy(currentAddress))
-                    .returns(Promise.resolve(mockEmptyOption<AccountId>()));
+                nodeApi.setup(instance => instance.queries.getRecoveryConfig(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
+                nodeApi.setup(instance => instance.queries.getProxy(currentAddress.address))
+                    .returns(Promise.resolve(undefined));
 
                 const legalOfficersAddresses = legalOfficers.map(legalOfficer => legalOfficer.address);
-                nodeApi.setup(instance => instance.tx.verifiedRecovery.createRecovery(It.Is<string[]>(
+                nodeApi.setup(instance => instance.polkadot.tx.verifiedRecovery.createRecovery(It.Is<string[]>(
                         addresses => addresses.every(address => legalOfficersAddresses.includes(address)))))
                     .returns(submittable.object());
             },
@@ -839,19 +822,18 @@ describe("PendingRecovery", () => {
                 factory.setupAuthenticatedDirectoryClientMock(LOGION_CLIENT_CONFIG, token);
 
                 const nodeApi = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-                const recoveryConfig = mockOption<PalletRecoveryRecoveryConfig>({
-                    friends: [
+                const recoveryConfig = {
+                    legalOfficers: [
                         ALICE.address,
                         BOB.address
                     ]
-                } as unknown as PalletRecoveryRecoveryConfig)
-                nodeApi.setup(instance => instance.query.recovery.recoverable(currentAddress.address))
-                    .returns(Promise.resolve(recoveryConfig as Option<PalletRecoveryRecoveryConfig>));
-                const proxy = mockOption<AccountId>(RECOVERED_ADDRESS as unknown as AccountId)
-                nodeApi.setup(instance => instance.query.recovery.proxy(currentAddress.address))
-                    .returns(Promise.resolve(proxy as Option<AccountId>));
+                };
+                nodeApi.setup(instance => instance.queries.getRecoveryConfig(currentAddress.address))
+                    .returns(Promise.resolve(recoveryConfig));
+                nodeApi.setup(instance => instance.queries.getProxy(currentAddress.address))
+                    .returns(Promise.resolve(RECOVERED_ADDRESS.address));
 
-                nodeApi.setup(instance => instance.tx.recovery.claimRecovery(RECOVERED_ADDRESS.address))
+                nodeApi.setup(instance => instance.polkadot.tx.recovery.claimRecovery(RECOVERED_ADDRESS.address))
                     .returns(submittable.object());
             },
             currentAddress,

--- a/packages/client/test/Token.spec.ts
+++ b/packages/client/test/Token.spec.ts
@@ -1,5 +1,3 @@
-import { LogionNodeApi } from "@logion/node-api";
-import { Mock } from "moq.ts";
 import {
     ItemTokenWithRestrictedType,
     TokenType,
@@ -7,6 +5,7 @@ import {
     isTokenType,
     isTokenCompatibleWith, NetworkType
 } from "../src/index.js";
+import { buildLogionNodeApiMock } from "./TestConfigFactory.js";
 
 const ercNonFungibleTypes: TokenType[] = [
     "ethereum_erc721",
@@ -141,11 +140,7 @@ function testNonFungibleErcValidToken(type: TokenType) {
 }
 
 function testValid(token: ItemTokenWithRestrictedType, polkadotAddress?: string) {
-    const api = new Mock<LogionNodeApi>();
-    if(polkadotAddress) {
-        api.setup(instance => instance.createType("AccountId", polkadotAddress))
-            .returns(undefined as any);
-    }
+    const api = buildLogionNodeApiMock();
     const result = validateToken(api.object(), token);
     expect(result.valid).toBe(true);
     expect(result.error).not.toBeDefined();
@@ -159,7 +154,8 @@ function testErcInvalidIdType(type: TokenType) {
 }
 
 function testInvalid(token: ItemTokenWithRestrictedType, message: string) {
-    const api = new Mock<LogionNodeApi>();
+    const api = buildLogionNodeApiMock();
+    api.setup(instance => instance.queries.isValidAccountId).returns(() => false);
     const result = validateToken(api.object(), token);
     expect(result.valid).toBe(false);
     expect(result.error).toBe(message);

--- a/packages/client/test/Utils.ts
+++ b/packages/client/test/Utils.ts
@@ -1,4 +1,5 @@
 import { DateTime } from "luxon";
+import { ApiPromise } from "@polkadot/api";
 import { Option, Vec, bool } from "@polkadot/types-codec";
 import type { Codec } from '@polkadot/types-codec/types';
 
@@ -15,7 +16,7 @@ import {
 } from "../src/index.js";
 import { TestConfigFactory } from "./TestConfigFactory.js";
 import { It } from "moq.ts";
-import { AccountType, AnyAccountId, LogionNodeApi, ValidAccountId } from "@logion/node-api";
+import { AccountType, AnyAccountId, LogionNodeApiClass, UUID, ValidAccountId } from "@logion/node-api";
 
 export const ALICE: LegalOfficer = {
     name: "Alice",
@@ -54,7 +55,7 @@ export const LEGAL_OFFICERS = [ ALICE, BOB, CHARLIE ];
 
 export const DIRECTORY_ENDPOINT = "https://directory.logion.network";
 
-export function buildAliceTokens(api: LogionNodeApi, expirationDateTime: DateTime): AccountTokens {
+export function buildAliceTokens(api: LogionNodeApiClass, expirationDateTime: DateTime): AccountTokens {
     return new AccountTokens(api, {
         [`Polkadot:${ALICE.address}`]: {
             value: "alice token",
@@ -63,7 +64,7 @@ export function buildAliceTokens(api: LogionNodeApi, expirationDateTime: DateTim
     });
 }
 
-export function buildAliceAndBobTokens(api: LogionNodeApi, expirationDateTime: DateTime): AccountTokens {
+export function buildAliceAndBobTokens(api: LogionNodeApiClass, expirationDateTime: DateTime): AccountTokens {
     return new AccountTokens(api, {
         [`Polkadot:${ALICE.address}`]: {
             value: "alice token",
@@ -209,15 +210,19 @@ export function buildValidPolkadotAccountId(address: string | undefined): ValidA
 export function buildValidAccountId(address: string | undefined, type: AccountType): ValidAccountId | undefined {
     if(address) {
         const api = buildSimpleNodeApi();
-        return new AnyAccountId(api, address, type).toValidAccountId();
+        return new AnyAccountId(api.polkadot, address, type).toValidAccountId();
     } else {
         return undefined;
     }
 }
 
-export function buildSimpleNodeApi(): LogionNodeApi {
+export function buildSimpleNodeApi(): LogionNodeApiClass {
     const api = {
         createType: () => undefined,
-    };
-    return api as unknown as LogionNodeApi;
+    } as unknown as ApiPromise;
+    return new LogionNodeApiClass(api);
+}
+
+export function ItIsUuid(expected: UUID): UUID {
+    return It.Is<UUID>(uuid => uuid.toString() === expected.toString());
 }

--- a/packages/client/test/Voter.spec.ts
+++ b/packages/client/test/Voter.spec.ts
@@ -1,7 +1,7 @@
-import { LogionNodeApi, UUID } from "@logion/node-api";
+import { LogionNodeApiClass, UUID } from "@logion/node-api";
 import { AxiosInstance, AxiosResponse } from "axios";
 import { DateTime } from "luxon";
-import { It, Mock } from "moq.ts";
+import { Mock } from "moq.ts";
 import {
     AccountTokens,
     SharedState,
@@ -14,6 +14,7 @@ import {
     buildSimpleNodeApi,
     buildTestAuthenticatedSharedSate,
     buildValidPolkadotAccountId,
+    ItIsUuid,
     LEGAL_OFFICERS,
     LOGION_CLIENT_CONFIG,
 } from "./Utils.js";
@@ -42,7 +43,7 @@ const LOC_REQUEST = buildLocRequest(ALICE.address, "CLOSED", "Identity");
 const LOC = buildLoc(ALICE.address, "CLOSED", "Identity");
 
 let aliceAxiosMock: Mock<AxiosInstance>;
-let nodeApiMock: Mock<LogionNodeApi>;
+let nodeApiMock: Mock<LogionNodeApiClass>;
 
 const currentAddress = buildValidPolkadotAccountId(ALICE.address);
 const token = "some-token";
@@ -73,9 +74,8 @@ async function buildSharedState(): Promise<SharedState> {
                 .returns(aliceAxiosMock.object());
 
             nodeApiMock = factory.setupNodeApiMock(LOGION_CLIENT_CONFIG);
-            nodeApiMock.setup(instance => instance.query.logionLoc.locMap(new UUID(LOC_REQUEST.id).toHexString()))
+            nodeApiMock.setup(instance => instance.queries.getLegalOfficerCase(ItIsUuid(new UUID(LOC_REQUEST.id))))
                 .returnsAsync(LOC);
-            nodeApiMock.setup(instance => instance.createType(It.IsAny())).returns(undefined);
         },
         currentAddress,
         LEGAL_OFFICERS,

--- a/packages/node-api/src/LocBatch.ts
+++ b/packages/node-api/src/LocBatch.ts
@@ -77,7 +77,7 @@ export class LocBatch {
         return map;
     }
 
-    private async getAvailableVerifiedIssuers(): Promise<Record<string, VerifiedIssuerType[]>> {
+    async getAvailableVerifiedIssuers(): Promise<Record<string, VerifiedIssuerType[]>> {
         this.availableVerifiedIssuers ||= await this.computeAvailableVerifiedIssuersMap();
         return this.availableVerifiedIssuers;
     }

--- a/packages/node-api/src/Queries.ts
+++ b/packages/node-api/src/Queries.ts
@@ -49,11 +49,11 @@ export class Queries {
     private api: ApiPromise;
     private adapters: Adapters;
 
-    isValidAccountId(accountId?: string | null): boolean {
+    isValidAccountId(accountId?: string | null, type?: AccountType): boolean {
         if(accountId === null || accountId === undefined || accountId === '') {
             return false;
         }
-        const anyAccountId = new AnyAccountId(this.api, accountId, "Polkadot");
+        const anyAccountId = new AnyAccountId(this.api, accountId, type || "Polkadot");
         return anyAccountId.isValid();
     }
 


### PR DESCRIPTION
* Removes all uses of deprecated `node-api` functions and types
* Fine-tune `node-api`

logion-network/logion-internal#839