### PR TITLE
Token ID must be explicitly hex encoded

### DIFF
--- a/packages/node-api/integration/CollectionLoc.ts
+++ b/packages/node-api/integration/CollectionLoc.ts
@@ -58,14 +58,32 @@ export async function addCollectionItemTest() {
     );
     await signAndSend(requester, addItem2Extrinsic);
 
+    const item3Id = "0x9ab7b28cd982c19262caa8ed7d8e33c53600c5f733a4961307a33b33f2c5a54f";
+    const item3TokenId = "5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb";
+    const addItem3Extrinsic = api.polkadot.tx.logionLoc.addCollectionItem(
+        api.adapters.toLocId(COLLECTION_LOC_ID),
+        item3Id,
+        "Item 3",
+        [],
+        Adapters.toCollectionItemToken({
+            id: item3TokenId,
+            type: "owner",
+        }),
+        false,
+    );
+    await signAndSend(requester, addItem3Extrinsic);
+
     const items = await api.queries.getCollectionItems(COLLECTION_LOC_ID);
-    expect(items.length).toBe(2);
+    expect(items.length).toBe(3);
 
     const item1 = await api.queries.getCollectionItem(COLLECTION_LOC_ID, item1Id);
     expect(item1?.id).toBe(item1Id);
 
     const item2 = await api.queries.getCollectionItem(COLLECTION_LOC_ID, item2Id);
     expect(item2?.id).toBe(item2Id);
+
+    const item3 = await api.queries.getCollectionItem(COLLECTION_LOC_ID, item3Id);
+    expect(item3?.id).toBe(item3Id);
 }
 
 const COLLECTION_LOC_ID = new UUID("3a07d3ae-a18d-43a4-8439-9c33532b7ff3");

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.16.0-1",
+  "version": "0.16.0-2",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/test/Adapters.spec.ts
+++ b/packages/node-api/test/Adapters.spec.ts
@@ -1,3 +1,4 @@
+import { stringToHex } from "@polkadot/util";
 import { Adapters, ItemFile, ItemToken, TermsAndConditionsElement, UUID } from "../src/index.js";
 
 describe("Adapters", () => {
@@ -28,7 +29,7 @@ describe("Adapters", () => {
             id: '{"contract":"0x765df6da33c1ec1f83be42db171d7ee334a46df5","token":"4391"}',
         };
         const adapted = Adapters.toCollectionItemToken(itemToken);
-        expect(adapted?.tokenId).toBe(itemToken.id);
+        expect(adapted?.tokenId).toBe(stringToHex(itemToken.id));
         expect(adapted?.tokenType).toBe(itemToken.type);
     });
 


### PR DESCRIPTION
* With "owner" tokens, the token ID may be an Ethereum address
* As Ethereum addresses are represented in hex-form, they are interpreted as raw bytes by Polkadot.js which leads to wrongly encoded UTF-8 strings, preventing the use of `toUtf8` method on `Raw` object.
* Token IDs are now explicitly hex-encoded so that they always represent a UTF-8 string (even if the string is in hex form).
* A fallback has been implemented to handle older data which were not double hex-encoded.
* Note that no owner tokens should have reached any production environment yet so the fallback can be removed once all test environments are reset.