### PR TITLE
Enable rework/cancel on reviewed requests

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.27.0-4",
+  "version": "0.27.0-5",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",


### PR DESCRIPTION
* A user may decide to cancel/rework a LOC request, even if it was accepted.

logion-network/logion-internal#911