### PR TITLE
Store hashes of LOC public data

### DIFF
--- a/packages/client/integration/TokensRecord.ts
+++ b/packages/client/integration/TokensRecord.ts
@@ -30,7 +30,7 @@ export async function tokensRecords(state: State) {
     await acceptedLoc.openCollection({ collectionMaxSize: 100, collectionCanUpload: true, signer });
     let aliceOpenLoc = await aliceAcceptedLoc.refresh() as OpenLoc;
 
-    await legalOfficer.selectIssuer(collectionLocId, ISSUER_ADDRESS, true);
+    await legalOfficer.selectIssuer(collectionLocId, ISSUER_ADDRESS);
     await aliceOpenLoc.legalOfficer.close({ signer });
 
     await initRequesterBalance(TEST_LOGION_CLIENT_CONFIG, state.signer, ISSUER_ADDRESS);

--- a/packages/client/integration/Utils.ts
+++ b/packages/client/integration/Utils.ts
@@ -171,7 +171,15 @@ export class LegalOfficerWorker {
         });
     }
 
-    async selectIssuer(locId: UUID, issuerAddress: string, selected: boolean) {
+    async selectIssuer(locId: UUID, issuerAddress: string) {
+        await this.setIssuerSelection(locId, issuerAddress, true);
+    }
+
+    async unselectIssuer(locId: UUID, issuerAddress: string) {
+        await this.setIssuerSelection(locId, issuerAddress, false);
+    }
+
+    private async setIssuerSelection(locId: UUID, issuerAddress: string, selected: boolean) {
         const api = await buildApiClass(TEST_LOGION_CLIENT_CONFIG.rpcEndpoints);
         const submittable = api.polkadot.tx.logionLoc.setIssuerSelection(api.adapters.toLocId(locId), issuerAddress, selected);
         await this.state.signer.signAndSend({

--- a/packages/client/integration/VerifiedIssuer.ts
+++ b/packages/client/integration/VerifiedIssuer.ts
@@ -84,7 +84,5 @@ export async function verifiedIssuer(state: State) {
 
     await legalOfficer.selectIssuer(newLoc.locId, ISSUER_ADDRESS, false);
     const userLoc = (await userClient.locsState()).findById(locId);
-    expect(userLoc.data().issuers.length).toBe(1);
-    expect(userLoc.data().issuers[0].identityLocId).toBe(closedIdentityLoc.locId.toString());
-    expect(userLoc.data().issuers[0].selected).toBe(false);
+    expect(userLoc.data().issuers.length).toBe(0);
 }

--- a/packages/client/integration/VerifiedIssuer.ts
+++ b/packages/client/integration/VerifiedIssuer.ts
@@ -2,7 +2,6 @@ import {
     ClosedLoc,
     EditableRequest,
     HashOrContent,
-    LocRequestState,
     AcceptedRequest,
     PendingRequest, OpenLoc
 } from "../src/index.js";
@@ -45,7 +44,7 @@ export async function verifiedIssuer(state: State) {
     await legalOfficer.nominateVerifiedIssuer(ISSUER_ADDRESS, closedIdentityLoc.locId);
 
     const userClient = state.client.withCurrentAddress(newAccount);
-    const userLocsState = await userClient.locsState();
+    let userLocsState = await userClient.locsState();
     let pendingLocRequest = await userLocsState.requestTransactionLoc({
         legalOfficer: userClient.getLegalOfficer(alice.address),
         description: "Some LOC with verified issuer",
@@ -55,13 +54,13 @@ export async function verifiedIssuer(state: State) {
     await legalOfficer.acceptLoc(locId);
 
     let acceptedLoc = await pendingLocRequest.refresh() as AcceptedRequest;
-    let newLoc = await acceptedLoc.open({ signer });
+    let openLoc = await acceptedLoc.open({ signer });
 
-    await legalOfficer.selectIssuer(locId, ISSUER_ADDRESS, true);
-    newLoc = await newLoc.refresh() as OpenLoc;
-    expect(newLoc.data().issuers.length).toBe(1);
-    expect(newLoc.data().issuers[0].identityLocId).toBe(closedIdentityLoc.locId.toString());
-    expect(newLoc.data().issuers[0].selected).toBe(true);
+    await legalOfficer.selectIssuer(locId, ISSUER_ADDRESS);
+    openLoc = await openLoc.refresh() as OpenLoc;
+    expect(openLoc.data().issuers.length).toBe(1);
+    expect(openLoc.data().issuers[0].identityLocId).toBe(closedIdentityLoc.locId.toString());
+    expect(openLoc.data().issuers[0].selected).toBe(true);
 
     issuerLocsState = await issuerClient.locsState();
     expect(issuerLocsState.openVerifiedIssuerLocs["Transaction"].length).toBe(1);
@@ -82,7 +81,8 @@ export async function verifiedIssuer(state: State) {
     });
     openIssuerLoc = await openIssuerLoc.deleteFile({ hash: file.contentHash });
 
-    await legalOfficer.selectIssuer(newLoc.locId, ISSUER_ADDRESS, false);
-    const userLoc = (await userClient.locsState()).findById(locId);
+    await legalOfficer.unselectIssuer(locId, ISSUER_ADDRESS);
+    userLocsState = await (await userClient.locsState()).refresh();
+    const userLoc = await userLocsState.findById(locId);
     expect(userLoc.data().issuers.length).toBe(0);
 }

--- a/packages/client/test/Hash.spec.ts
+++ b/packages/client/test/Hash.spec.ts
@@ -1,4 +1,4 @@
-import { HashOrContent } from "../src/index.js";
+import { HashOrContent, Hash } from "../src/index.js";
 
 describe("HashOrContent", () => {
 
@@ -21,7 +21,7 @@ describe("HashOrContent", () => {
     });
 
     it("detects invalid hash (no prefix)", () => {
-        expect(() => HashOrContent.fromHash(INVALID_HASH_NO_PREFIX)).toThrow();
+        expect(() => HashOrContent.fromHash(INVALID_HASH_NO_PREFIX as Hash)).toThrow();
     });
 
     it("detects invalid hash (not hexa)", () => {

--- a/packages/client/test/LocUtils.ts
+++ b/packages/client/test/LocUtils.ts
@@ -82,7 +82,7 @@ export function buildLoc(ownerAddress: string, status: LocRequestStatus, locType
         files: [
             {
                 hash: EXISTING_FILE_HASH,
-                nature: "Some nature",
+                nature: "0xf85455e7f9269c18b042ced52395324f78d482502049c80456581054fa9cb852", // "Some nature",
                 submitter: requester,
                 size: 128n,
                 acknowledged: status === "CLOSED",

--- a/packages/node-api/integration/Adapters.ts
+++ b/packages/node-api/integration/Adapters.ts
@@ -1,4 +1,4 @@
-import { UUID } from "../src/index.js";
+import { UUID, MetadataItemParams } from "../src/index.js";
 import { setup } from "./Util.js";
 
 export async function toPalletLogionLocOtherAccountId() {
@@ -29,15 +29,15 @@ export async function toPalletLogionLocMetadataItem() {
     const validPolkadotAccountId = api.queries.getValidAccountId(polkadotAddress, "Polkadot");
 
     const submitter = validPolkadotAccountId;
-    const item = {
-        name: "a_name",
-        value: "a_value",
+    const item: MetadataItemParams = {
+        name: "0x6bccbb4801b2d1f5abb5b0f0540add342716edf347721911f7b12d00af715ec0", // "a_name",
+        value: "0xba3781303cb841808fee0d46e315d6f76367b1842d38c26d8946bc6456920498", // "a_value",
         submitter,
     };
     const palletItem = api.adapters.toPalletLogionLocMetadataItem(item);
 
-    expect(palletItem.name.toHex()).toBe("0x615f6e616d65");
-    expect(palletItem.value.toHex()).toBe("0x615f76616c7565");
+    expect(palletItem.name.toHex()).toBe(item.name);
+    expect(palletItem.value.toHex()).toBe(item.value);
     expect(palletItem.submitter.asPolkadot.toString()).toBe(polkadotAddress);
 }
 
@@ -50,7 +50,7 @@ export async function toPalletLogionLocFile() {
 
     const submitter = validPolkadotAccountId;
     const hash = "0x91820202c3d0fea0c494b53e3352f1934bc177484e3f41ca2c4bca4572d71cd2";
-    const nature = "file-nature";
+    const nature = "0x8d9661f02e30e4d9c0aa5542c4fe4b2e517ff0f42e0b3551cd79c7bc66005c28" // "file-nature";
     const size = BigInt(128000);
     const palletFile = api.adapters.toPalletLogionLocFile({
         hash,
@@ -59,7 +59,7 @@ export async function toPalletLogionLocFile() {
         submitter,
     });
     expect(palletFile.hash_.toHex()).toBe(hash);
-    expect(palletFile.nature.toUtf8()).toBe(nature);
+    expect(palletFile.nature.toHex()).toBe(nature);
     expect(palletFile.size_.toBigInt()).toBe(size);
     expect(palletFile.submitter.asPolkadot.toString()).toBe(polkadotAddress);
 }

--- a/packages/node-api/integration/TransactionLoc.ts
+++ b/packages/node-api/integration/TransactionLoc.ts
@@ -1,4 +1,4 @@
-import { UUID, MetadataItem, File } from "../src/index.js";
+import { UUID, MetadataItemParams, FileParams } from "../src/index.js";
 import { ALICE, REQUESTER, setup, signAndSend } from "./Util.js";
 import { IKeyringPair } from "@polkadot/types/types";
 
@@ -21,27 +21,35 @@ export async function createTransactionLocTest() {
 
 export async function addMetadataToTransactionLocTestAsLLO() {
     const { alice, api } = await setup();
-    await addMetadataToTransactionLocTest(alice, {
-        name: "Some name",
-        value: "Some value",
-        submitter: api.queries.getValidAccountId(ALICE, "Polkadot"),
-        acknowledged: true,
-    }, 0);
+    await addMetadataToTransactionLocTest(
+        alice,
+        {
+            name: "0x3794097220b25a099e23755c53f7f673b60885d101bd67873070d887419a0603", // "Some name",
+            value: "0xcc68b65c670cea83c4b9e110822af132258d882b7bc79c3f3645bdec06131e71", // "Some value",
+            submitter: api.queries.getValidAccountId(ALICE, "Polkadot"),
+        },
+        true,
+        0
+    );
 }
 
 export async function addMetadataToTransactionLocTestAsRequester() {
     const { api, requester } = await setup();
-    await addMetadataToTransactionLocTest(requester, {
-        name: REQUESTER_METADATA_NAME,
-        value: "Some other value",
-        submitter: api.queries.getValidAccountId(REQUESTER, "Polkadot"),
-        acknowledged: false,
-    }, 1);
+    await addMetadataToTransactionLocTest(
+        requester,
+        {
+            name: REQUESTER_METADATA_NAME,
+            value: "0xbcb90db0ba3340c794a7d75982598a1ce1468a7a69e1f960d99c203d36af5c85", // "Some other value",
+            submitter: api.queries.getValidAccountId(REQUESTER, "Polkadot"),
+        },
+        false,
+        1
+    );
 }
 
-async function addMetadataToTransactionLocTest(who: IKeyringPair, item: MetadataItem, index: number) {
+async function addMetadataToTransactionLocTest(who: IKeyringPair, item: MetadataItemParams, expectedAcknowledged: boolean, index: number) {
     const { api } = await setup();
-    const { name, value, submitter, acknowledged } = item
+    const { name, value, submitter } = item
     const addMetadataExtrinsic = api.polkadot.tx.logionLoc.addMetadata(
         api.adapters.toLocId(TRANSACTION_LOC_ID),
         api.adapters.toPalletLogionLocMetadataItem({
@@ -58,7 +66,7 @@ async function addMetadataToTransactionLocTest(who: IKeyringPair, item: Metadata
     expect(loc?.metadata[index].value).toBe(value);
     expect(loc?.metadata[index].submitter.address).toBe(submitter.address);
     expect(loc?.metadata[index].submitter.type).toBe(submitter.type);
-    expect(loc?.metadata[index].acknowledged).toBe(acknowledged);
+    expect(loc?.metadata[index].acknowledged).toBe(expectedAcknowledged);
 }
 
 export async function acknowledgeMetadata() {
@@ -77,31 +85,37 @@ export async function acknowledgeMetadata() {
 export async function addFileToTransactionLocTestAsLLO() {
     const { alice, api } = await setup();
 
-    await addFileToTransactionLocTest(alice, {
-        hash: "0x46d9bb04725470dc8483395f635805e9da5e105c7b2b90935b895a0f4f364d80",
-        nature: "Some nature",
-        submitter: api.queries.getValidAccountId(ALICE, "Polkadot"),
-        size: BigInt(456),
-        acknowledged: true,
-    }, 0);
+    await addFileToTransactionLocTest(
+        alice,
+        {
+            hash: "0x46d9bb04725470dc8483395f635805e9da5e105c7b2b90935b895a0f4f364d80",
+            nature: "0xf85455e7f9269c18b042ced52395324f78d482502049c80456581054fa9cb852", // "Some nature",
+            submitter: api.queries.getValidAccountId(ALICE, "Polkadot"),
+            size: BigInt(456),
+        },
+        true,
+        0);
 }
 
 export async function addFileToTransactionLocTestAsRequester() {
     const { requester, api } = await setup();
 
-    await addFileToTransactionLocTest(requester, {
-        hash: REQUESTER_FILE_HASH,
-        nature: "Some other nature",
-        submitter: api.queries.getValidAccountId(REQUESTER, "Polkadot"),
-        size: BigInt(123),
-        acknowledged: false,
-    }, 1);
+    await addFileToTransactionLocTest(
+        requester,
+        {
+            hash: REQUESTER_FILE_HASH,
+            nature: "0x043f4d83c1e3fa7146fd182ad01577f3df3151a30ec0952c1e06ce2361eee5dc", // "Some other nature",
+            submitter: api.queries.getValidAccountId(REQUESTER, "Polkadot"),
+            size: BigInt(123),
+        },
+        false,
+        1);
 }
 
-async function addFileToTransactionLocTest(who: IKeyringPair, file: File, index: number) {
+async function addFileToTransactionLocTest(who: IKeyringPair, file: FileParams, expectedAcknowledged: boolean, index: number) {
     const { api } = await setup();
 
-    const { hash, nature, size, submitter, acknowledged } = file;
+    const { hash, nature, size, submitter } = file;
 
     const addFileExtrinsic = api.polkadot.tx.logionLoc.addFile(
         api.adapters.toLocId(TRANSACTION_LOC_ID),
@@ -121,7 +135,7 @@ async function addFileToTransactionLocTest(who: IKeyringPair, file: File, index:
     expect(loc?.files[index].submitter.address).toBe(submitter.address);
     expect(loc?.files[index].submitter.type).toBe(submitter.type);
     expect(loc?.files[index].size).toBe(size);
-    expect(loc?.files[index].acknowledged).toBe(acknowledged);
+    expect(loc?.files[index].acknowledged).toBe(expectedAcknowledged);
 }
 
 export async function acknowledgeFile() {
@@ -139,5 +153,5 @@ export async function acknowledgeFile() {
 
 
 const TRANSACTION_LOC_ID = new UUID("c1dc4b62-714b-4001-ae55-1b54ad61dd93");
-const REQUESTER_METADATA_NAME = "Some other name";
+const REQUESTER_METADATA_NAME = "0xee99a660b04af4cfd0569fe63e011c919ea66ff7d6ede6d104b03a57540446e5" // "Some other name";
 const REQUESTER_FILE_HASH = "0xb741477ee8b0f12dbf1094487c3832145911f6e55ced5dbe57c3248a18f0461b";

--- a/packages/node-api/integration/VerifiedIssuers.ts
+++ b/packages/node-api/integration/VerifiedIssuers.ts
@@ -1,5 +1,5 @@
 import { Currency, UUID, Adapters } from "../src/index.js";
-import { ALICE, ISSUER, REQUESTER, setup, signAndSend, signAndSendBatch } from "./Util.js";
+import { ALICE, ISSUER, setup, signAndSend, signAndSendBatch } from "./Util.js";
 
 export async function verifiedIssuers() {
     const { api, alice, issuer, requester } = await setup();
@@ -22,8 +22,8 @@ export async function verifiedIssuers() {
     await signAndSendBatch(alice, [
         api.polkadot.tx.logionLoc.setIssuerSelection(collectionLocId.toDecimalString(), ISSUER, true),
         api.polkadot.tx.logionLoc.addMetadata(collectionLocId.toDecimalString(), api.adapters.toPalletLogionLocMetadataItem({
-            name: "Test",
-            value: "Test",
+            name: "0x532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25", // "Test",
+            value: "0x532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25", // "Test",
             submitter: api.queries.getValidAccountId(ISSUER, "Polkadot"),
         })),
         api.polkadot.tx.logionLoc.close(collectionLocId.toDecimalString()),

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.16.0",
+  "version": "0.17.0-1",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/Adapters.ts
+++ b/packages/node-api/src/Adapters.ts
@@ -96,21 +96,21 @@ export class Adapters {
             requesterAddress,
             requesterLocId: rawLoc.requester.isLoc ? UUID.fromDecimalString(rawLoc.requester.asLoc.toString()) : undefined,
             metadata: rawLoc.metadata.toArray().map(rawItem => ({
-                name: rawItem.name.toUtf8(),
-                value: rawItem.value.toUtf8(),
+                name: rawItem.name.toHex(),
+                value: rawItem.value.toHex(),
                 submitter: this.fromPalletLogionLocSupportedAccountId(rawItem.submitter),
                 acknowledged: rawItem.acknowledged.isTrue,
             })),
             files: rawLoc.files.toArray().map(rawFile => ({
                 hash: rawFile.hash_.toHex(),
-                nature: rawFile.nature.toUtf8(),
+                nature: rawFile.nature.toHex(),
                 submitter: this.fromPalletLogionLocSupportedAccountId(rawFile.submitter),
                 size: rawFile.size_.toBigInt(),
                 acknowledged: rawFile.acknowledged.isTrue,
             })),
             links: rawLoc.links.toArray().map(rawLink => ({
                 id: UUID.fromDecimalStringOrThrow(rawLink.id.toString()),
-                nature: rawLink.nature.toUtf8()
+                nature: rawLink.nature.toHex()
             })),
             closed: rawLoc.closed.isTrue,
             locType: rawLoc.locType.toString() as LocType,
@@ -407,8 +407,8 @@ export class Adapters {
 
     toPalletLogionLocMetadataItem(item: MetadataItemParams): PalletLogionLocMetadataItemParams {
         return this.api.createType("PalletLogionLocMetadataItemParams", {
-            name: stringToHex(item.name),
-            value: stringToHex(item.value),
+            name: item.name,
+            value: item.value,
             submitter: this.toPalletLogionLocSupportedAccountId(item.submitter),
         });
     }

--- a/packages/node-api/src/FeesEstimator.ts
+++ b/packages/node-api/src/FeesEstimator.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from "@polkadot/api";
 import { SubmittableExtrinsic } from "@polkadot/api/promise/types.js";
 import { UUID } from "./UUID.js";
 import { Adapters } from "./Adapters.js";
-import { ValidAccountId, LocType } from "./Types.js";
+import { ValidAccountId, LocType, Hash } from "./Types.js";
 
 export class Fees {
 
@@ -33,8 +33,8 @@ export class FeesEstimator {
 
     async estimateAddFile(args: {
         locId: UUID,
-        hash: string,
-        nature: string,
+        hash: Hash,
+        nature: Hash,
         submitter: ValidAccountId,
         size: bigint,
         origin: string,

--- a/packages/node-api/src/Types.ts
+++ b/packages/node-api/src/Types.ts
@@ -10,9 +10,12 @@ export interface TypesAccountData {
     total: string,
 }
 
+type HexNumber = string;
+export type Hash = `0x${ HexNumber }`;
+
 export interface MetadataItemParams {
-    name: string;
-    value: string;
+    name: Hash;
+    value: Hash;
     submitter: ValidAccountId;
 }
 
@@ -21,8 +24,8 @@ export interface MetadataItem extends MetadataItemParams {
 }
 
 export interface FileParams {
-    hash: string;
-    nature: string;
+    hash: Hash;
+    nature: Hash;
     submitter: ValidAccountId;
     size: bigint;
 }
@@ -33,7 +36,7 @@ export interface File extends FileParams {
 
 export interface Link {
     id: UUID;
-    nature: string;
+    nature: Hash;
 }
 
 export interface LegalOfficerCase {

--- a/packages/node-api/src/interfaces/augment-api-tx.ts
+++ b/packages/node-api/src/interfaces/augment-api-tx.ts
@@ -655,7 +655,7 @@ declare module '@polkadot/api-base/types/submittable' {
       /**
        * Acknowledge a metadata item.
        **/
-      acknowledgeMetadata: AugmentedSubmittable<(locId: Compact<u128> | AnyNumber | Uint8Array, name: Bytes | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [Compact<u128>, Bytes]>;
+      acknowledgeMetadata: AugmentedSubmittable<(locId: Compact<u128> | AnyNumber | Uint8Array, name: H256 | string | Uint8Array) => SubmittableExtrinsic<ApiType>, [Compact<u128>, H256]>;
       /**
        * Adds an item to a collection
        **/

--- a/packages/node-api/src/interfaces/default/definitions.ts
+++ b/packages/node-api/src/interfaces/default/definitions.ts
@@ -49,13 +49,13 @@ export default {
             sponsorship_id: "Option<SponsorshipId>",
         },
         MetadataItemParams: {
-            name: "Vec<u8>",
-            value: "Vec<u8>",
+            name: "Hash",
+            value: "Hash",
             submitter: "SupportedAccountId"
         },
         MetadataItem: {
-            name: "Vec<u8>",
-            value: "Vec<u8>",
+            name: "Hash",
+            value: "Hash",
             submitter: "SupportedAccountId",
             acknowledged: "bool"
         },
@@ -68,16 +68,16 @@ export default {
         },
         LocLink: {
             id: "LocId",
-            nature: "Vec<u8>",
+            nature: "Hash",
         },
         FileParams: {
             hash: "Hash",
-            nature: "Vec<u8>",
+            nature: "Hash",
             submitter: "SupportedAccountId"
         },
         File: {
             hash: "Hash",
-            nature: "Vec<u8>",
+            nature: "Hash",
             submitter: "SupportedAccountId",
             acknowledged: "bool"
         },

--- a/packages/node-api/src/interfaces/default/types.ts
+++ b/packages/node-api/src/interfaces/default/types.ts
@@ -86,7 +86,7 @@ export interface CollectionSize extends u32 {}
 /** @name File */
 export interface File extends Struct {
   readonly hash: Hash;
-  readonly nature: Bytes;
+  readonly nature: Hash;
   readonly submitter: SupportedAccountId;
   readonly acknowledged: bool;
 }
@@ -94,7 +94,7 @@ export interface File extends Struct {
 /** @name FileParams */
 export interface FileParams extends Struct {
   readonly hash: Hash;
-  readonly nature: Bytes;
+  readonly nature: Hash;
   readonly submitter: SupportedAccountId;
 }
 
@@ -152,7 +152,7 @@ export interface LocId extends u128 {}
 /** @name LocLink */
 export interface LocLink extends Struct {
   readonly id: LocId;
-  readonly nature: Bytes;
+  readonly nature: Hash;
 }
 
 /** @name LocType */
@@ -176,16 +176,16 @@ export interface LogionVote extends Struct {
 
 /** @name MetadataItem */
 export interface MetadataItem extends Struct {
-  readonly name: Bytes;
-  readonly value: Bytes;
+  readonly name: Hash;
+  readonly value: Hash;
   readonly submitter: SupportedAccountId;
   readonly acknowledged: bool;
 }
 
 /** @name MetadataItemParams */
 export interface MetadataItemParams extends Struct {
-  readonly name: Bytes;
-  readonly value: Bytes;
+  readonly name: Hash;
+  readonly value: Hash;
   readonly submitter: SupportedAccountId;
 }
 

--- a/packages/node-api/src/interfaces/lookup.ts
+++ b/packages/node-api/src/interfaces/lookup.ts
@@ -1459,7 +1459,7 @@ export default {
       },
       acknowledge_metadata: {
         locId: 'Compact<u128>',
-        name: 'Bytes',
+        name: 'H256',
       },
       acknowledge_file: {
         _alias: {
@@ -1471,11 +1471,11 @@ export default {
     }
   },
   /**
-   * Lookup158: pallet_logion_loc::MetadataItemParams<sp_core::crypto::AccountId32, primitive_types::H160>
+   * Lookup158: pallet_logion_loc::MetadataItemParams<sp_core::crypto::AccountId32, primitive_types::H160, primitive_types::H256>
    **/
   PalletLogionLocMetadataItemParams: {
-    name: 'Bytes',
-    value: 'Bytes',
+    name: 'H256',
+    value: 'H256',
     submitter: 'PalletLogionLocSupportedAccountId'
   },
   /**
@@ -1487,16 +1487,16 @@ export default {
       size_: 'size'
     },
     hash_: 'H256',
-    nature: 'Bytes',
+    nature: 'H256',
     submitter: 'PalletLogionLocSupportedAccountId',
     size_: 'u32'
   },
   /**
-   * Lookup160: pallet_logion_loc::LocLink<LocId>
+   * Lookup160: pallet_logion_loc::LocLink<LocId, primitive_types::H256>
    **/
   PalletLogionLocLocLink: {
     id: 'u128',
-    nature: 'Bytes'
+    nature: 'H256'
   },
   /**
    * Lookup162: pallet_logion_loc::CollectionItemFile<primitive_types::H256>
@@ -1751,11 +1751,11 @@ export default {
     }
   },
   /**
-   * Lookup200: pallet_logion_loc::MetadataItem<sp_core::crypto::AccountId32, primitive_types::H160>
+   * Lookup200: pallet_logion_loc::MetadataItem<sp_core::crypto::AccountId32, primitive_types::H160, primitive_types::H256>
    **/
   PalletLogionLocMetadataItem: {
-    name: 'Bytes',
-    value: 'Bytes',
+    name: 'H256',
+    value: 'H256',
     submitter: 'PalletLogionLocSupportedAccountId',
     acknowledged: 'bool'
   },
@@ -1768,7 +1768,7 @@ export default {
       size_: 'size'
     },
     hash_: 'H256',
-    nature: 'Bytes',
+    nature: 'H256',
     submitter: 'PalletLogionLocSupportedAccountId',
     size_: 'u32',
     acknowledged: 'bool'
@@ -1835,7 +1835,7 @@ export default {
    * Lookup223: pallet_logion_loc::pallet::StorageVersion
    **/
   PalletLogionLocStorageVersion: {
-    _enum: ['V1', 'V2MakeLocVoid', 'V3RequesterEnum', 'V4ItemSubmitter', 'V5Collection', 'V6ItemUpload', 'V7ItemToken', 'V8AddSeal', 'V9TermsAndConditions', 'V10AddLocFileSize', 'V11EnableEthereumSubmitter', 'V12Sponsorship', 'V13AcknowledgeItems']
+    _enum: ['V1', 'V2MakeLocVoid', 'V3RequesterEnum', 'V4ItemSubmitter', 'V5Collection', 'V6ItemUpload', 'V7ItemToken', 'V8AddSeal', 'V9TermsAndConditions', 'V10AddLocFileSize', 'V11EnableEthereumSubmitter', 'V12Sponsorship', 'V13AcknowledgeItems', 'V14HashLocPublicData']
   },
   /**
    * Lookup224: pallet_logion_loc::pallet::Error<T>

--- a/packages/node-api/src/interfaces/types-lookup.ts
+++ b/packages/node-api/src/interfaces/types-lookup.ts
@@ -1606,7 +1606,7 @@ declare module '@polkadot/types/lookup' {
     readonly isAcknowledgeMetadata: boolean;
     readonly asAcknowledgeMetadata: {
       readonly locId: Compact<u128>;
-      readonly name: Bytes;
+      readonly name: H256;
     } & Struct;
     readonly isAcknowledgeFile: boolean;
     readonly asAcknowledgeFile: {
@@ -1618,15 +1618,15 @@ declare module '@polkadot/types/lookup' {
 
   /** @name PalletLogionLocMetadataItemParams (158) */
   interface PalletLogionLocMetadataItemParams extends Struct {
-    readonly name: Bytes;
-    readonly value: Bytes;
+    readonly name: H256;
+    readonly value: H256;
     readonly submitter: PalletLogionLocSupportedAccountId;
   }
 
   /** @name PalletLogionLocFileParams (159) */
   interface PalletLogionLocFileParams extends Struct {
     readonly hash_: H256;
-    readonly nature: Bytes;
+    readonly nature: H256;
     readonly submitter: PalletLogionLocSupportedAccountId;
     readonly size_: u32;
   }
@@ -1634,7 +1634,7 @@ declare module '@polkadot/types/lookup' {
   /** @name PalletLogionLocLocLink (160) */
   interface PalletLogionLocLocLink extends Struct {
     readonly id: u128;
-    readonly nature: Bytes;
+    readonly nature: H256;
   }
 
   /** @name PalletLogionLocCollectionItemFile (162) */
@@ -1945,8 +1945,8 @@ declare module '@polkadot/types/lookup' {
 
   /** @name PalletLogionLocMetadataItem (200) */
   interface PalletLogionLocMetadataItem extends Struct {
-    readonly name: Bytes;
-    readonly value: Bytes;
+    readonly name: H256;
+    readonly value: H256;
     readonly submitter: PalletLogionLocSupportedAccountId;
     readonly acknowledged: bool;
   }
@@ -1954,7 +1954,7 @@ declare module '@polkadot/types/lookup' {
   /** @name PalletLogionLocFile (202) */
   interface PalletLogionLocFile extends Struct {
     readonly hash_: H256;
-    readonly nature: Bytes;
+    readonly nature: H256;
     readonly submitter: PalletLogionLocSupportedAccountId;
     readonly size_: u32;
     readonly acknowledged: bool;
@@ -2025,7 +2025,8 @@ declare module '@polkadot/types/lookup' {
     readonly isV11EnableEthereumSubmitter: boolean;
     readonly isV12Sponsorship: boolean;
     readonly isV13AcknowledgeItems: boolean;
-    readonly type: 'V1' | 'V2MakeLocVoid' | 'V3RequesterEnum' | 'V4ItemSubmitter' | 'V5Collection' | 'V6ItemUpload' | 'V7ItemToken' | 'V8AddSeal' | 'V9TermsAndConditions' | 'V10AddLocFileSize' | 'V11EnableEthereumSubmitter' | 'V12Sponsorship' | 'V13AcknowledgeItems';
+    readonly isV14HashLocPublicData: boolean;
+    readonly type: 'V1' | 'V2MakeLocVoid' | 'V3RequesterEnum' | 'V4ItemSubmitter' | 'V5Collection' | 'V6ItemUpload' | 'V7ItemToken' | 'V8AddSeal' | 'V9TermsAndConditions' | 'V10AddLocFileSize' | 'V11EnableEthereumSubmitter' | 'V12Sponsorship' | 'V13AcknowledgeItems' | 'V14HashLocPublicData';
   }
 
   /** @name PalletLogionLocError (224) */

--- a/packages/node-api/test/FeesEstimator.spec.ts
+++ b/packages/node-api/test/FeesEstimator.spec.ts
@@ -29,7 +29,7 @@ describe("FeesEstimator", () => {
         const fees = await estimator.estimateAddFile({
             locId: new UUID(LOC_REQUEST_ID),
             hash: "0xf2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
-            nature: "Some nature",
+            nature: "0xf85455e7f9269c18b042ced52395324f78d482502049c80456581054fa9cb852", // "Some nature",
             submitter: mockValidAccountId(DEFAULT_LEGAL_OFFICER),
             size: BigInt(42),
             origin: DEFAULT_LEGAL_OFFICER,

--- a/packages/node-api/test/Queries.spec.ts
+++ b/packages/node-api/test/Queries.spec.ts
@@ -160,10 +160,10 @@ function mockPolkadotApiForLogionLoc() {
                         metadata: {
                             toArray: () => DEFAULT_LOC.metadata.map(item => ({
                                 name: {
-                                    toUtf8: () => item.name
+                                    toHex: () => item.name
                                 },
                                 value: {
-                                    toUtf8: () => item.value
+                                    toHex: () => item.value
                                 },
                                 submitter: {
                                     isPolkadot: true,
@@ -180,7 +180,7 @@ function mockPolkadotApiForLogionLoc() {
                                     toHex: () => file.hash
                                 },
                                 nature: {
-                                    toUtf8: () => file.nature
+                                    toHex: () => file.nature
                                 },
                                 submitter: {
                                     isPolkadot: true,
@@ -200,7 +200,7 @@ function mockPolkadotApiForLogionLoc() {
                                     toString: () => link.id.toDecimalString()
                                 },
                                 nature: {
-                                    toUtf8: () => link.nature
+                                    toHex: () => link.nature
                                 }
                             }))
                         },
@@ -264,8 +264,8 @@ export const DEFAULT_LOC: LegalOfficerCase = {
     requesterAddress: mockValidAccountId("5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb"),
     metadata: [
         {
-            name: "meta_name",
-            value: "meta_value",
+            name: "0x5beec8d95ab31db54c7fa04b4ad9f8f803d0f3c02dc5f92f01315525b1e7a418", // "meta_name",
+            value: "0x4825b5bf0234ae4bb2f01eae996a4b96b0166ccf807ab4b555f035cb786d7300", // "meta_value",
             submitter: mockValidAccountId("owner"),
             acknowledged: true,
         }
@@ -273,7 +273,7 @@ export const DEFAULT_LOC: LegalOfficerCase = {
     files: [
         {
             hash: "0x91820202c3d0fea0c494b53e3352f1934bc177484e3f41ca2c4bca4572d71cd2",
-            nature: "file-nature",
+            nature: "0x8d9661f02e30e4d9c0aa5542c4fe4b2e517ff0f42e0b3551cd79c7bc66005c28", // "file-nature",
             submitter: mockValidAccountId("owner"),
             size: BigInt(128000),
             acknowledged: true,
@@ -282,7 +282,7 @@ export const DEFAULT_LOC: LegalOfficerCase = {
     links: [
         {
             id: new UUID("90fcde7e-a255-404e-8b15-32963a4e64c0"),
-            nature: "file-nature"
+            nature: "0xd70a29488f030b5636f7e8ac37d2ac8cb910a04fdaf4e3e2b660b8171df354d0", // "link-nature"
         }
     ],
     closed: false,


### PR DESCRIPTION
* Companion of https://github.com/logion-network/logion-pallets/pull/28
* **logion-api**: A new lightweight type is introduced: `Hash`. It serves 2 purposes:
  * Correctly document where hash or actual data is expected (`nature: Hash` vs `nature: string`)
  * Provides a basic check of hash literals at compile time: they must start with `0x`.
* **client**:
  * The API is not changed, hashing is done before submitting to the chain.
  * Value is hidden when the recorded hash does not match the calculated one.
___
Not included in this PR:
`publishLink()` does not exist yet. It should work similarly (hashing of nature) and be added to the LO SDK.

logion-network/logion-internal#929