### PR TITLE
Support for MultiversX addresses, tokens and signatures.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.28.0",
+  "version": "0.28.1-3",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Signer.ts
+++ b/packages/client/src/Signer.ts
@@ -18,7 +18,7 @@ export interface SignRawParameters {
     attributes: any[]; // eslint-disable-line @typescript-eslint/no-explicit-any
 }
 
-export type SignatureType = "POLKADOT" | "ETHEREUM" | "CROSSMINT_ETHEREUM";
+export type SignatureType = "POLKADOT" | "ETHEREUM" | "CROSSMINT_ETHEREUM" | "MULTIVERSX";
 
 export interface TypedSignature {
     signature: string

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/extension",
-  "version": "0.5.16",
+  "version": "0.5.17-1",
   "description": "logion SDK for Polkadot JS extension",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/multiversx/.npmignore
+++ b/packages/multiversx/.npmignore
@@ -1,0 +1,9 @@
+/test/**
+/integration/**
+/src/**
+/scripts/**
+docker-compose.yml
+front_config.js
+front_web*.conf
+jasmine*.json
+tsconfig*.json

--- a/packages/multiversx/jasmine.json
+++ b/packages/multiversx/jasmine.json
@@ -1,0 +1,15 @@
+{
+  "spec_dir": "test",
+  "spec_files": [
+    "**/*.spec.ts"
+  ],
+  "helpers": [
+    "typescript.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "reporters": [
+    {
+      "name": "jasmine-spec-reporter#SpecReporter"
+    }
+  ]
+}

--- a/packages/multiversx/package.json
+++ b/packages/multiversx/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@logion/crossmint",
-  "version": "0.1.19-1",
-  "description": "logion SDK for Crossmint",
+  "name": "@logion/multiversx",
+  "version": "0.1.0-4",
+  "description": "logion SDK for MultiversX",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",
   "type": "module",
@@ -13,7 +13,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/logion-network/logion-api.git",
-    "directory": "packages/crossmint"
+    "directory": "packages/multiversx"
   },
   "keywords": [
     "logion"
@@ -21,8 +21,9 @@
   "author": "Logion Team",
   "license": "Apache-2.0",
   "dependencies": {
-    "@crossmint/connect": "^0.0.8",
-    "@logion/client": "workspace:^"
+    "@logion/client": "workspace:^",
+    "@multiversx/sdk-core": "^12.4.3",
+    "@multiversx/sdk-extension-provider": "^2.0.7"
   },
   "bugs": {
     "url": "https://github.com/logion-network/logion-api/issues"
@@ -46,6 +47,6 @@
   "stableVersion": "0.1.0",
   "typedoc": {
     "entryPoint": "./src/index.ts",
-    "displayName": "Crossmint"
+    "displayName": "MultiversX"
   }
 }

--- a/packages/multiversx/src/MultiversxSigner.ts
+++ b/packages/multiversx/src/MultiversxSigner.ts
@@ -1,0 +1,36 @@
+import { BaseSigner, SignAndSendFunction, TypedSignature } from "@logion/client";
+import { ValidAccountId } from "@logion/node-api";
+import { SignableMessage } from "@multiversx/sdk-core";
+import { ExtensionProvider } from "@multiversx/sdk-extension-provider";
+
+export class MultiversxSigner extends BaseSigner {
+
+    constructor() {
+        super();
+        this.provider = ExtensionProvider.getInstance();
+    }
+
+    private readonly provider: ExtensionProvider;
+
+    async login(): Promise<string> {
+        if (await this.provider.init()) {
+            return await this.provider.login();
+        } else {
+            throw new Error("No MultiversX account available");
+        }
+    }
+
+    async signToHex(_signerId: ValidAccountId, message: string): Promise<TypedSignature> {
+        const signableMessage = new SignableMessage({
+            message: Buffer.from(message.substring(2), "hex")
+        });
+        const signedMessage = await this.provider.signMessage(signableMessage);
+        const signature = '0x' + signedMessage.getSignature().toString('hex');
+        return { signature, type: "MULTIVERSX" }
+    }
+
+    buildSignAndSendFunction(): Promise<SignAndSendFunction> {
+        throw new Error("Cannot sign and send extrinsics with MultiversX signer");
+    }
+
+}

--- a/packages/multiversx/src/index.ts
+++ b/packages/multiversx/src/index.ts
@@ -1,0 +1,1 @@
+export * from './MultiversxSigner.js';

--- a/packages/multiversx/tsconfig.json
+++ b/packages/multiversx/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist"
+  },
+  "include": [
+    "./src/**/*"
+  ]
+}

--- a/packages/multiversx/tsconfig.test.json
+++ b/packages/multiversx/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "include": [
+    "./src/**/*",
+    "./test/**/*",
+    "./integration/**/*"
+  ]
+}

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.17.0",
+  "version": "0.17.1-2",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3235,6 +3235,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@logion/multiversx@workspace:packages/multiversx":
+  version: 0.0.0-use.local
+  resolution: "@logion/multiversx@workspace:packages/multiversx"
+  dependencies:
+    "@logion/client": "workspace:^"
+    "@multiversx/sdk-core": ^12.4.3
+    "@multiversx/sdk-extension-provider": ^2.0.7
+    "@tsconfig/node18": ^1.0.1
+    "@types/node": ^18.6.1
+    "@typescript-eslint/eslint-plugin": latest
+    "@typescript-eslint/parser": latest
+    eslint: ^8.20.0
+    jasmine: ^4.3.0
+    jasmine-spec-reporter: ^7.0.0
+    moq.ts: ^9.0.2
+    ts-node: ^10.9.1
+    typescript: ^4.7.4
+  languageName: unknown
+  linkType: soft
+
 "@logion/node-api@workspace:^, @logion/node-api@workspace:packages/node-api":
   version: 0.0.0-use.local
   resolution: "@logion/node-api@workspace:packages/node-api"
@@ -3307,6 +3327,38 @@ __metadata:
   version: 2.0.0
   resolution: "@metamask/detect-provider@npm:2.0.0"
   checksum: 45d3128069310e6cdb9a572b31da88b3fddb0aa78f94deba71657efd7e40d0680912a4ee0291a7a0e9ab66681aba271e74de87c5464d979f115726c740db641b
+  languageName: node
+  linkType: hard
+
+"@multiversx/sdk-core@npm:^12.4.3":
+  version: 12.4.3
+  resolution: "@multiversx/sdk-core@npm:12.4.3"
+  dependencies:
+    "@multiversx/sdk-transaction-decoder": 1.0.2
+    bech32: 1.1.4
+    bignumber.js: 9.0.1
+    blake2b: 2.1.3
+    buffer: 6.0.3
+    json-duplicate-key-handle: 1.0.0
+    keccak: 3.0.2
+    protobufjs: 6.11.3
+  checksum: ed417d0cc6171d05112d03026cea56ce8b623055c4c150f50f8cea6fd0dd993f878ee0be712882ca24d8c62e7e962634f730547928b45be0e496375d7d973bae
+  languageName: node
+  linkType: hard
+
+"@multiversx/sdk-extension-provider@npm:^2.0.7":
+  version: 2.0.7
+  resolution: "@multiversx/sdk-extension-provider@npm:2.0.7"
+  checksum: 59f58db28a6af79f6ab35b5346119e7d55676a31dd0cc9d409350e3c12cb0a5b8f9e4e7747fdc66a7f636e6b53896737e8b56730d16a498f7f7b3fd5c55b4601
+  languageName: node
+  linkType: hard
+
+"@multiversx/sdk-transaction-decoder@npm:1.0.2":
+  version: 1.0.2
+  resolution: "@multiversx/sdk-transaction-decoder@npm:1.0.2"
+  dependencies:
+    bech32: ^2.0.0
+  checksum: ff0192a4bcb6fec27e643e982fdbd7634ccb0c1ebeed48e83c84e61079d076adbe309fcf90a7cb5075de310ef5984e711da4b71fd51e20bc604b39aa29e86316
   languageName: node
   linkType: hard
 
@@ -3891,6 +3943,79 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@protobufjs/aspromise@npm:^1.1.1, @protobufjs/aspromise@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/aspromise@npm:1.1.2"
+  checksum: 011fe7ef0826b0fd1a95935a033a3c0fd08483903e1aa8f8b4e0704e3233406abb9ee25350ec0c20bbecb2aad8da0dcea58b392bbd77d6690736f02c143865d2
+  languageName: node
+  linkType: hard
+
+"@protobufjs/base64@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/base64@npm:1.1.2"
+  checksum: 67173ac34de1e242c55da52c2f5bdc65505d82453893f9b51dc74af9fe4c065cf4a657a4538e91b0d4a1a1e0a0642215e31894c31650ff6e3831471061e1ee9e
+  languageName: node
+  linkType: hard
+
+"@protobufjs/codegen@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "@protobufjs/codegen@npm:2.0.4"
+  checksum: 59240c850b1d3d0b56d8f8098dd04787dcaec5c5bd8de186fa548de86b86076e1c50e80144b90335e705a044edf5bc8b0998548474c2a10a98c7e004a1547e4b
+  languageName: node
+  linkType: hard
+
+"@protobufjs/eventemitter@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/eventemitter@npm:1.1.0"
+  checksum: 0369163a3d226851682f855f81413cbf166cd98f131edb94a0f67f79e75342d86e89df9d7a1df08ac28be2bc77e0a7f0200526bb6c2a407abbfee1f0262d5fd7
+  languageName: node
+  linkType: hard
+
+"@protobufjs/fetch@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/fetch@npm:1.1.0"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.1
+    "@protobufjs/inquire": ^1.1.0
+  checksum: 3fce7e09eb3f1171dd55a192066450f65324fd5f7cc01a431df01bb00d0a895e6bfb5b0c5561ce157ee1d886349c90703d10a4e11a1a256418ff591b969b3477
+  languageName: node
+  linkType: hard
+
+"@protobufjs/float@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@protobufjs/float@npm:1.0.2"
+  checksum: 5781e1241270b8bd1591d324ca9e3a3128d2f768077a446187a049e36505e91bc4156ed5ac3159c3ce3d2ba3743dbc757b051b2d723eea9cd367bfd54ab29b2f
+  languageName: node
+  linkType: hard
+
+"@protobufjs/inquire@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/inquire@npm:1.1.0"
+  checksum: ca06f02eaf65ca36fb7498fc3492b7fc087bfcc85c702bac5b86fad34b692bdce4990e0ef444c1e2aea8c034227bd1f0484be02810d5d7e931c55445555646f4
+  languageName: node
+  linkType: hard
+
+"@protobufjs/path@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "@protobufjs/path@npm:1.1.2"
+  checksum: 856eeb532b16a7aac071cacde5c5620df800db4c80cee6dbc56380524736205aae21e5ae47739114bf669ab5e8ba0e767a282ad894f3b5e124197cb9224445ee
+  languageName: node
+  linkType: hard
+
+"@protobufjs/pool@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/pool@npm:1.1.0"
+  checksum: d6a34fbbd24f729e2a10ee915b74e1d77d52214de626b921b2d77288bd8f2386808da2315080f2905761527cceffe7ec34c7647bd21a5ae41a25e8212ff79451
+  languageName: node
+  linkType: hard
+
+"@protobufjs/utf8@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@protobufjs/utf8@npm:1.1.0"
+  checksum: f9bf3163d13aaa3b6f5e6fbf37a116e094ea021c0e1f2a7ccd0e12a29e2ce08dafba4e8b36e13f8ed7397e1591610ce880ed1289af4d66cf4ace8a36a9557278
+  languageName: node
+  linkType: hard
+
 "@scure/base@npm:1.1.1":
   version: 1.1.1
   resolution: "@scure/base@npm:1.1.1"
@@ -4429,6 +4554,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/long@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "@types/long@npm:4.0.2"
+  checksum: d16cde7240d834cf44ba1eaec49e78ae3180e724cd667052b194a372f350d024cba8dd3f37b0864931683dab09ca935d52f0c4c1687178af5ada9fc85b0635f4
+  languageName: node
+  linkType: hard
+
 "@types/luxon@npm:^3.0.0":
   version: 3.0.0
   resolution: "@types/luxon@npm:3.0.0"
@@ -4463,6 +4595,13 @@ __metadata:
   version: 17.0.31
   resolution: "@types/node@npm:17.0.31"
   checksum: 704618350f8420d5c47db0f7778398e821b7724369946f5c441a7e6b9343295553936400eb8309f0b07d5e39c240988ab3456b983712ca86265dabc9aee4ad3d
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:>=13.7.0":
+  version: 20.3.2
+  resolution: "@types/node@npm:20.3.2"
+  checksum: 5929ce2b9b12b1e2a2304a0921a953c72a81f5753ad39ac43b99ce6312fbb2b4fb5bc6b60d64a2550704e3223cd5de1299467d36085ac69888899db978f2653a
   languageName: node
   linkType: hard
 
@@ -5489,6 +5628,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"backslash@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "backslash@npm:0.2.0"
+  checksum: 844996d595dfb57aa725dad7b37dce658367d54de58992d607e003a8250fc14e1fce8705c132f77d973d84fc27126bfde0428a60775ea93626a7aa3340652fbb
+  languageName: node
+  linkType: hard
+
 "bail@npm:^1.0.0":
   version: 1.0.5
   resolution: "bail@npm:1.0.5"
@@ -5549,6 +5695,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bech32@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "bech32@npm:2.0.0"
+  checksum: fa15acb270b59aa496734a01f9155677b478987b773bf701f465858bf1606c6a970085babd43d71ce61895f1baa594cb41a2cd1394bd2c6698f03cc2d811300e
+  languageName: node
+  linkType: hard
+
 "big.js@npm:^5.2.2":
   version: 5.2.2
   resolution: "big.js@npm:5.2.2"
@@ -5563,6 +5716,13 @@ __metadata:
     bindings: ^1.3.0
     node-gyp: latest
   checksum: d010c9f57758bcdaccb435d88b483ffcc95fe8bbc6e7fb3a44fb5221f29c894ffaf4a3c5a4a530e0e7d6608203c2cde9b79ee4f2386cd6d4462d1070bc8c9f4e
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:9.0.1":
+  version: 9.0.1
+  resolution: "bignumber.js@npm:9.0.1"
+  checksum: 6e72f6069d9db32fc8d27561164de9f811b15f9144be61f323d8b36150a239eea50c92e20ba38af2ba5e717af10b8ef12db8f9948fe2ff02bf17ede5239d15d3
   languageName: node
   linkType: hard
 
@@ -5586,6 +5746,25 @@ __metadata:
   dependencies:
     file-uri-to-path: 1.0.0
   checksum: 65b6b48095717c2e6105a021a7da4ea435aa8d3d3cd085cb9e85bcb6e5773cf318c4745c3f7c504412855940b585bdf9b918236612a1c7a7942491de176f1ae7
+  languageName: node
+  linkType: hard
+
+"blake2b-wasm@npm:^1.1.0":
+  version: 1.1.7
+  resolution: "blake2b-wasm@npm:1.1.7"
+  dependencies:
+    nanoassert: ^1.0.0
+  checksum: be5ebacdd25076ae5fcaf1c60c37096c85490a36ee1f8e78d5c4c2fb8ccad0fe0e22cecadba6fcf6ed7d91c1aed9c55980811fe064fafb4ccd80ac34a8a326ea
+  languageName: node
+  linkType: hard
+
+"blake2b@npm:2.1.3":
+  version: 2.1.3
+  resolution: "blake2b@npm:2.1.3"
+  dependencies:
+    blake2b-wasm: ^1.1.0
+    nanoassert: ^1.0.0
+  checksum: e652234249cbdb3345488d52b5e76e8572b8e5333f3f0d5e716772b7c5d2142f433c3fe86130e92117329532e1d1235cdaa89f40bbca27a8ae528bef428241ef
   languageName: node
   linkType: hard
 
@@ -5835,6 +6014,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"buffer@npm:6.0.3, buffer@npm:~6.0.3":
+  version: 6.0.3
+  resolution: "buffer@npm:6.0.3"
+  dependencies:
+    base64-js: ^1.3.1
+    ieee754: ^1.2.1
+  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
+  languageName: node
+  linkType: hard
+
 "buffer@npm:^5.0.5, buffer@npm:^5.5.0, buffer@npm:^5.6.0":
   version: 5.7.1
   resolution: "buffer@npm:5.7.1"
@@ -5842,16 +6031,6 @@ __metadata:
     base64-js: ^1.3.1
     ieee754: ^1.1.13
   checksum: e2cf8429e1c4c7b8cbd30834ac09bd61da46ce35f5c22a78e6c2f04497d6d25541b16881e30a019c6fd3154150650ccee27a308eff3e26229d788bbdeb08ab84
-  languageName: node
-  linkType: hard
-
-"buffer@npm:~6.0.3":
-  version: 6.0.3
-  resolution: "buffer@npm:6.0.3"
-  dependencies:
-    base64-js: ^1.3.1
-    ieee754: ^1.2.1
-  checksum: 5ad23293d9a731e4318e420025800b42bf0d264004c0286c8cc010af7a270c7a0f6522e84f54b9ad65cbd6db20b8badbfd8d2ebf4f80fa03dab093b89e68c3f9
   languageName: node
   linkType: hard
 
@@ -10163,6 +10342,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-duplicate-key-handle@npm:1.0.0":
+  version: 1.0.0
+  resolution: "json-duplicate-key-handle@npm:1.0.0"
+  dependencies:
+    backslash: ^0.2.0
+  checksum: a9d34d3e3f08a7de8bf60cbd49ec0ca044de89377b16cc63b3bc1c338bae7c56c8d706e4f811753bd5e82f5b8578895da8e709416f5ae965a50c426895073e6c
+  languageName: node
+  linkType: hard
+
 "json-parse-even-better-errors@npm:^2.3.0, json-parse-even-better-errors@npm:^2.3.1":
   version: 2.3.1
   resolution: "json-parse-even-better-errors@npm:2.3.1"
@@ -10274,7 +10462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"keccak@npm:^3.0.0":
+"keccak@npm:3.0.2, keccak@npm:^3.0.0":
   version: 3.0.2
   resolution: "keccak@npm:3.0.2"
   dependencies:
@@ -10464,6 +10652,13 @@ __metadata:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+  languageName: node
+  linkType: hard
+
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
   languageName: node
   linkType: hard
 
@@ -11101,6 +11296,13 @@ __metadata:
   version: 0.1.2
   resolution: "nano-json-stream-parser@npm:0.1.2"
   checksum: 5bfe146358c659e0aa7d5e0003416be929c9bd02ba11b1e022b78dddf25be655e33d810249c1687d2c9abdcee5cd4d00856afd1b266a5a127236c0d16416d33a
+  languageName: node
+  linkType: hard
+
+"nanoassert@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "nanoassert@npm:1.1.0"
+  checksum: f360fe639db8edc422de9f5a8a7d384ba9c11e9c6fac149f7ad3b0a94e4ec9d5aa44ce55b3e4c7682658efad792604fc96c336b0e80a3590744104ba58af80c7
   languageName: node
   linkType: hard
 
@@ -12424,6 +12626,30 @@ __metadata:
   dependencies:
     xtend: ^4.0.0
   checksum: fcf87c6542e59a8bbe31ca0b3255a4a63ac1059b01b04469680288998bcfa97f341ca989566adbb63975f4d85339030b82320c324a511532d390910d1c583893
+  languageName: node
+  linkType: hard
+
+"protobufjs@npm:6.11.3":
+  version: 6.11.3
+  resolution: "protobufjs@npm:6.11.3"
+  dependencies:
+    "@protobufjs/aspromise": ^1.1.2
+    "@protobufjs/base64": ^1.1.2
+    "@protobufjs/codegen": ^2.0.4
+    "@protobufjs/eventemitter": ^1.1.0
+    "@protobufjs/fetch": ^1.1.0
+    "@protobufjs/float": ^1.0.2
+    "@protobufjs/inquire": ^1.1.0
+    "@protobufjs/path": ^1.1.2
+    "@protobufjs/pool": ^1.1.0
+    "@protobufjs/utf8": ^1.1.0
+    "@types/long": ^4.0.1
+    "@types/node": ">=13.7.0"
+    long: ^4.0.0
+  bin:
+    pbjs: bin/pbjs
+    pbts: bin/pbts
+  checksum: 4a6ce1964167e4c45c53fd8a312d7646415c777dd31b4ba346719947b88e61654912326101f927da387d6b6473ab52a7ea4f54d6f15d63b31130ce28e2e15070
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
* add support for MultiversX [tokens](https://github.com/multiversx/mx-specs/blob/main/ESDT-specs.md) and [Bech32 addresses](https://en.bitcoin.it/wiki/BIP_0173).
* provides validation for tokens ID's.
* provides basic validation of Bech32 addresses - can be improved later on.
* add a new extension for signing with [MultiversX DeFi Extension](https://addons.mozilla.org/en-US/firefox/addon/multiversx-defi-wallet/).

logion-network/logion-internal#945