### PR TITLE
Move fee estimation to SDK

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.29.0",
+  "version": "0.30.0-1",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.30.0-3",
+  "version": "0.30.0-5",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.30.0-1",
+  "version": "0.30.0-3",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -51,7 +51,7 @@ import {
     EstimateFeesPublishFileParams,
     EstimateFeesPublishMetadataParams,
     EstimateFeesPublishLinkParams,
-    EstimateFeesOpenCollectionLocParams, OpenPolkadotLocParams,
+    EstimateFeesOpenCollectionLocParams, OpenPolkadotLocParams, EstimateFeesAddCollectionItemParams,
 } from "./LocClient.js";
 import { SharedState } from "./SharedClient.js";
 import { LegalOfficer, UserIdentity, PostalAddress, LegalOfficerClass } from "./Types.js";
@@ -1793,6 +1793,14 @@ export class ClosedCollectionLoc extends ClosedOrVoidCollectionLoc {
             ...parameters
         })
         return this;
+    }
+
+    async estimateFeesAddCollectionItem(parameters: EstimateFeesAddCollectionItemParams): Promise<FeesClass> {
+        const client = this.locSharedState.client;
+        return client.estimateFeesAddCollectionItem({
+            locId: this.locId,
+            ...parameters
+        })
     }
 
     async uploadCollectionItemFile(parameters: UploadCollectionItemFileParams): Promise<ClosedCollectionLoc> {

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -1164,6 +1164,10 @@ export class LegalOfficerPendingRequestCommands {
                 requesterAccount,
                 sponsorshipId,
             });
+        } else {
+            // Acceptance of a Collection is always a pure backend operation (no onchain operation),
+            // thus there is no fees.
+            return undefined;
         }
     }
 }

--- a/packages/crossmint/package.json
+++ b/packages/crossmint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/crossmint",
-  "version": "0.1.22",
+  "version": "0.1.23-1",
   "description": "logion SDK for Crossmint",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/extension",
-  "version": "0.5.20",
+  "version": "0.5.21-1",
   "description": "logion SDK for Polkadot JS extension",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/multiversx/package.json
+++ b/packages/multiversx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/multiversx",
-  "version": "0.1.3",
+  "version": "0.1.4-1",
   "description": "logion SDK for MultiversX",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.19.0",
+  "version": "0.20.0-1",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.20.0-1",
+  "version": "0.20.0-2",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/Connection.ts
+++ b/packages/node-api/src/Connection.ts
@@ -30,7 +30,7 @@ export class LogionNodeApiClass {
     constructor(api: ApiPromise) {
         this.polkadot = api;
         this.adapters = new Adapters(api);
-        this.fees = new FeesEstimator(api, this.adapters);
+        this.fees = new FeesEstimator(api);
         this.queries = new Queries(api, this.adapters);
     }
 

--- a/packages/node-api/src/FeesEstimator.ts
+++ b/packages/node-api/src/FeesEstimator.ts
@@ -98,4 +98,23 @@ export class FeesEstimator {
         const fee = await this.api.call.feesApi.queryCertificateFee(tokenIssuance);
         return fee.toBigInt();
     }
+
+    async estimateAddCollectionItem(params: {
+        origin: string,
+        submittable: SubmittableExtrinsic,
+        numOfEntries: bigint,
+        totSize: bigint,
+        tokenIssuance: bigint | undefined,
+    }): Promise<Fees> {
+        const { origin, submittable, numOfEntries, totSize } = params;
+        const tokenIssuance = params.tokenIssuance || 0n;
+        const inclusionFee = await this.estimateInclusionFee(origin, submittable);
+        const storageFee = await this.estimateStorageFee({ numOfEntries, totSize })
+        const certificateFee = await this.estimateCertificateFee({ tokenIssuance })
+        return new Fees({
+            inclusionFee,
+            storageFee,
+            certificateFee,
+        });
+    }
 }

--- a/packages/node-api/src/FeesEstimator.ts
+++ b/packages/node-api/src/FeesEstimator.ts
@@ -1,9 +1,6 @@
 import { ApiPromise } from "@polkadot/api";
 import { SubmittableExtrinsic } from "@polkadot/api/promise/types.js";
-import { UUID } from "./UUID.js";
-import { Adapters } from "./Adapters.js";
-import { ValidAccountId, LocType } from "./Types.js";
-import { Hash } from "./Hash.js";
+import { LocType } from "./Types.js";
 
 export class Fees {
 
@@ -39,27 +36,21 @@ export class Fees {
 
 export class FeesEstimator {
 
-    constructor(api: ApiPromise, adapters: Adapters) {
+    constructor(api: ApiPromise) {
         this.api = api;
-        this.adapters = adapters;
     }
 
     private readonly api: ApiPromise;
-    private readonly adapters: Adapters;
 
-    async estimateAddFile(args: {
-        locId: UUID,
-        hash: Hash,
-        nature: Hash,
-        submitter: ValidAccountId,
-        size: bigint,
+    async estimateWithStorage(params: {
         origin: string,
+        submittable: SubmittableExtrinsic,
+        size: bigint,
     }): Promise<Fees> {
-        const submittable = this.api.tx.logionLoc.addFile(Adapters.toLocId(args.locId), this.adapters.toPalletLogionLocFile(args));
-        const inclusionFee = await this.estimateInclusionFee(args.origin, submittable);
+        const inclusionFee = await this.estimateInclusionFee(params.origin, params.submittable);
         const storageFee = await this.estimateStorageFee({
             numOfEntries: 1n,
-            totSize: args.size,
+            totSize: params.size,
         });
         return new Fees({ inclusionFee, storageFee });
     }


### PR DESCRIPTION
For each operation to the blockchain `nnn()`, a new method is added `estimateFeesNnn()` - that estimates the Fees for the operation. In order to ensure accurate calculation, all parameters required for the blockchain operation are also required to estimate the fees, so we have:
```
async nnn(params: NnnParams & BlockchainSubmissionParams): Promise<void> {};

async estimateFeesNnn(params: NnnParams): Promise<Fees> {};
```
https://github.com/logion-network/logion-internal/issues/904