### PR TITLE
Adapt node-api to item acknowledge by issuer.

### DIFF
--- a/packages/client/test/LocUtils.ts
+++ b/packages/client/test/LocUtils.ts
@@ -82,7 +82,8 @@ export function buildLoc(ownerAddress: string, status: LocRequestStatus, locType
                 nature: Hash.of("Some nature"),
                 submitter: requester,
                 size: 128n,
-                acknowledged: status === "CLOSED",
+                acknowledgedByOwner: status === "CLOSED",
+                acknowledgedByVerifiedIssuer: false,
             }
         ],
         links: [],

--- a/packages/node-api/integration/Main.spec.ts
+++ b/packages/node-api/integration/Main.spec.ts
@@ -9,10 +9,14 @@ import {
     createTransactionLocTest,
     addMetadataToTransactionLocTestAsLLO,
     addMetadataToTransactionLocTestAsRequester,
-    acknowledgeMetadata,
+    acknowledgeMetadataAsOwner,
     addFileToTransactionLocTestAsLLO,
     addFileToTransactionLocTestAsRequester,
-    acknowledgeFile
+    acknowledgeFileAsOwner,
+    addFileToTransactionLocTestAsIssuer,
+    acknowledgeFileAsIssuer,
+    acknowledgeMetadataAsIssuer,
+    addMetadataToTransactionLocTestAsIssuer
 } from "./TransactionLoc.js";
 import { createVote } from "./Vote.js";
 import { verifiedIssuers } from "./VerifiedIssuers.js";
@@ -44,11 +48,15 @@ describe("Logion Node API", () => {
 
     it("adds metadata to transaction LOC (LLO)", addMetadataToTransactionLocTestAsLLO);
     it("adds metadata to transaction LOC (Requester)", addMetadataToTransactionLocTestAsRequester);
-    it("acknowledges metadata (LLO)", acknowledgeMetadata)
+    it("adds metadata to transaction LOC (Verified Issuer)", addMetadataToTransactionLocTestAsIssuer);
+    it("acknowledges metadata (LLO)", acknowledgeMetadataAsOwner);
+    it("acknowledges metadata (Verified Issuer)", acknowledgeMetadataAsIssuer);
 
     it("adds file to transaction LOC (LLO)", addFileToTransactionLocTestAsLLO);
     it("adds file to transaction LOC (Requester)", addFileToTransactionLocTestAsRequester);
-    it("acknowledges file (LLO)", acknowledgeFile)
+    it("adds file to transaction LOC (Verified Issuer)", addFileToTransactionLocTestAsIssuer);
+    it("acknowledges file (LLO)", acknowledgeFileAsOwner);
+    it("acknowledges file (VerifiedIssuer)", acknowledgeFileAsIssuer);
 
     it("creates collection LOC limited in size", createCollectionLocLimitedInSizeTest);
     it("closes collection LOC", closeCollectionLocTest);

--- a/packages/node-api/integration/TransactionLoc.ts
+++ b/packages/node-api/integration/TransactionLoc.ts
@@ -1,5 +1,5 @@
 import { UUID, MetadataItemParams, FileParams, Hash } from "../src/index.js";
-import { ALICE, REQUESTER, setup, signAndSend } from "./Util.js";
+import { ALICE, REQUESTER, setup, signAndSend, ISSUER } from "./Util.js";
 import { IKeyringPair } from "@polkadot/types/types";
 
 export async function createTransactionLocTest() {
@@ -47,7 +47,21 @@ export async function addMetadataToTransactionLocTestAsRequester() {
     );
 }
 
-async function addMetadataToTransactionLocTest(who: IKeyringPair, item: MetadataItemParams, expectedAcknowledged: boolean, index: number) {
+export async function addMetadataToTransactionLocTestAsIssuer() {
+    const { api, requester } = await setup();
+    await addMetadataToTransactionLocTest(
+        requester,
+        {
+            name: ISSUER_METADATA_NAME,
+            value: Hash.of("Some other value (bis)"),
+            submitter: api.queries.getValidAccountId(ISSUER, "Polkadot"),
+        },
+        false,
+        2
+    );
+}
+
+async function addMetadataToTransactionLocTest(who: IKeyringPair, item: MetadataItemParams, expectedAcknowledgedByOwner: boolean, index: number) {
     const { api } = await setup();
     const { name, value, submitter } = item
     const addMetadataExtrinsic = api.polkadot.tx.logionLoc.addMetadata(
@@ -62,10 +76,11 @@ async function addMetadataToTransactionLocTest(who: IKeyringPair, item: Metadata
     expect(loc?.metadata[index].value).toEqual(value);
     expect(loc?.metadata[index].submitter.address).toBe(submitter.address);
     expect(loc?.metadata[index].submitter.type).toBe(submitter.type);
-    expect(loc?.metadata[index].acknowledged).toBe(expectedAcknowledged);
+    expect(loc?.metadata[index].acknowledgedByOwner).toBe(expectedAcknowledgedByOwner);
+    expect(loc?.metadata[index].acknowledgedByVerifiedIssuer).toBeFalse();
 }
 
-export async function acknowledgeMetadata() {
+export async function acknowledgeMetadataAsOwner() {
     const { alice, api } = await setup();
     const acknowledgeMetadataExtrinsic = api.polkadot.tx.logionLoc.acknowledgeMetadata(
         api.adapters.toLocId(TRANSACTION_LOC_ID),
@@ -74,8 +89,20 @@ export async function acknowledgeMetadata() {
     await signAndSend(alice, acknowledgeMetadataExtrinsic);
 
     const loc = await api.queries.getLegalOfficerCase(TRANSACTION_LOC_ID);
-    expect(loc?.metadata[0].acknowledged).toBeTrue();
-    expect(loc?.metadata[1].acknowledged).toBeTrue();
+    expect(loc?.metadata[0].acknowledgedByOwner).toBeTrue();
+    expect(loc?.metadata[1].acknowledgedByOwner).toBeTrue();
+}
+
+export async function acknowledgeMetadataAsIssuer() {
+    const { issuer, api } = await setup();
+    const acknowledgeMetadataExtrinsic = api.polkadot.tx.logionLoc.acknowledgeMetadata(
+        api.adapters.toLocId(TRANSACTION_LOC_ID),
+        ISSUER_FILE_HASH.bytes,
+    );
+    await signAndSend(issuer, acknowledgeMetadataExtrinsic);
+
+    const loc = await api.queries.getLegalOfficerCase(TRANSACTION_LOC_ID);
+    expect(loc?.metadata[2].acknowledgedByVerifiedIssuer).toBeTrue();
 }
 
 export async function addFileToTransactionLocTestAsLLO() {
@@ -108,7 +135,22 @@ export async function addFileToTransactionLocTestAsRequester() {
         1);
 }
 
-async function addFileToTransactionLocTest(who: IKeyringPair, file: FileParams, expectedAcknowledged: boolean, index: number) {
+export async function addFileToTransactionLocTestAsIssuer() {
+    const { requester, api } = await setup();
+
+    await addFileToTransactionLocTest(
+        requester,
+        {
+            hash: ISSUER_FILE_HASH,
+            nature: Hash.of("Some other nature (bis)"),
+            submitter: api.queries.getValidAccountId(ISSUER, "Polkadot"),
+            size: BigInt(789),
+        },
+        false,
+        2);
+}
+
+async function addFileToTransactionLocTest(who: IKeyringPair, file: FileParams, expectedAcknowledgedByOwner: boolean, index: number) {
     const { api } = await setup();
 
     const { hash, nature, size, submitter } = file;
@@ -126,10 +168,11 @@ async function addFileToTransactionLocTest(who: IKeyringPair, file: FileParams, 
     expect(loc?.files[index].submitter.address).toBe(submitter.address);
     expect(loc?.files[index].submitter.type).toBe(submitter.type);
     expect(loc?.files[index].size).toBe(size);
-    expect(loc?.files[index].acknowledged).toBe(expectedAcknowledged);
+    expect(loc?.files[index].acknowledgedByOwner).toBe(expectedAcknowledgedByOwner);
+    expect(loc?.files[index].acknowledgedByVerifiedIssuer).toBeFalse();
 }
 
-export async function acknowledgeFile() {
+export async function acknowledgeFileAsOwner() {
     const { alice, api } = await setup();
     const acknowledgeFileExtrinsic = api.polkadot.tx.logionLoc.acknowledgeFile(
         api.adapters.toLocId(TRANSACTION_LOC_ID),
@@ -138,11 +181,25 @@ export async function acknowledgeFile() {
     await signAndSend(alice, acknowledgeFileExtrinsic);
 
     const loc = await api.queries.getLegalOfficerCase(TRANSACTION_LOC_ID);
-    expect(loc?.files[0].acknowledged).toBeTrue();
-    expect(loc?.files[1].acknowledged).toBeTrue();
+    expect(loc?.files[0].acknowledgedByOwner).toBeTrue();
+    expect(loc?.files[1].acknowledgedByOwner).toBeTrue();
+}
+
+export async function acknowledgeFileAsIssuer() {
+    const { issuer, api } = await setup();
+    const acknowledgeFileExtrinsic = api.polkadot.tx.logionLoc.acknowledgeFile(
+        api.adapters.toLocId(TRANSACTION_LOC_ID),
+        ISSUER_FILE_HASH.bytes,
+    );
+    await signAndSend(issuer, acknowledgeFileExtrinsic);
+
+    const loc = await api.queries.getLegalOfficerCase(TRANSACTION_LOC_ID);
+    expect(loc?.files[2].acknowledgedByVerifiedIssuer).toBeTrue();
 }
 
 
 const TRANSACTION_LOC_ID = new UUID("c1dc4b62-714b-4001-ae55-1b54ad61dd93");
 const REQUESTER_METADATA_NAME = Hash.of("Some other name");
+const ISSUER_METADATA_NAME = Hash.of("Yet some other name");
 const REQUESTER_FILE_HASH = Hash.fromHex("0xb741477ee8b0f12dbf1094487c3832145911f6e55ced5dbe57c3248a18f0461b");
+const ISSUER_FILE_HASH = Hash.fromHex("0x4df3c3f68fcc83b27e9d42c90431a72499f17875c81a599b566c9889b9696703");

--- a/packages/node-api/src/Adapters.ts
+++ b/packages/node-api/src/Adapters.ts
@@ -102,14 +102,16 @@ export class Adapters {
                 name: Hash.fromHex(rawItem.name.toHex()),
                 value: Hash.fromHex(rawItem.value.toHex()),
                 submitter: this.fromPalletLogionLocSupportedAccountId(rawItem.submitter),
-                acknowledged: rawItem.acknowledged.isTrue,
+                acknowledgedByOwner: rawItem.acknowledgedByOwner.isTrue,
+                acknowledgedByVerifiedIssuer: rawItem.acknowledgedByVerifiedIssuer.isTrue,
             })),
             files: rawLoc.files.toArray().map(rawFile => ({
                 hash: Hash.fromHex(rawFile.hash_.toHex()),
                 nature: Hash.fromHex(rawFile.nature.toHex()),
                 submitter: this.fromPalletLogionLocSupportedAccountId(rawFile.submitter),
                 size: rawFile.size_.toBigInt(),
-                acknowledged: rawFile.acknowledged.isTrue,
+                acknowledgedByOwner: rawFile.acknowledgedByOwner.isTrue,
+                acknowledgedByVerifiedIssuer: rawFile.acknowledgedByVerifiedIssuer.isTrue,
             })),
             links: rawLoc.links.toArray().map(rawLink => ({
                 id: UUID.fromDecimalStringOrThrow(rawLink.id.toString()),

--- a/packages/node-api/src/Types.ts
+++ b/packages/node-api/src/Types.ts
@@ -18,7 +18,8 @@ export interface MetadataItemParams {
 }
 
 export interface MetadataItem extends MetadataItemParams {
-    acknowledged: boolean;
+    acknowledgedByOwner: boolean;
+    acknowledgedByVerifiedIssuer: boolean;
 }
 
 export interface FileParams {
@@ -29,7 +30,8 @@ export interface FileParams {
 }
 
 export interface File extends FileParams {
-    acknowledged: boolean;
+    acknowledgedByOwner: boolean;
+    acknowledgedByVerifiedIssuer: boolean;
 }
 
 export interface Link {

--- a/packages/node-api/src/interfaces/lookup.ts
+++ b/packages/node-api/src/interfaces/lookup.ts
@@ -1805,7 +1805,8 @@ export default {
     name: 'H256',
     value: 'H256',
     submitter: 'PalletLogionLocSupportedAccountId',
-    acknowledged: 'bool'
+    acknowledgedByOwner: 'bool',
+    acknowledgedByVerifiedIssuer: 'bool'
   },
   /**
    * Lookup203: pallet_logion_loc::File<primitive_types::H256, sp_core::crypto::AccountId32, primitive_types::H160>
@@ -1819,7 +1820,8 @@ export default {
     nature: 'H256',
     submitter: 'PalletLogionLocSupportedAccountId',
     size_: 'u32',
-    acknowledged: 'bool'
+    acknowledgedByOwner: 'bool',
+    acknowledgedByVerifiedIssuer: 'bool'
   },
   /**
    * Lookup204: pallet_logion_loc::LocType
@@ -1870,7 +1872,7 @@ export default {
    * Lookup219: pallet_logion_loc::pallet::StorageVersion
    **/
   PalletLogionLocStorageVersion: {
-    _enum: ['V1', 'V2MakeLocVoid', 'V3RequesterEnum', 'V4ItemSubmitter', 'V5Collection', 'V6ItemUpload', 'V7ItemToken', 'V8AddSeal', 'V9TermsAndConditions', 'V10AddLocFileSize', 'V11EnableEthereumSubmitter', 'V12Sponsorship', 'V13AcknowledgeItems', 'V14HashLocPublicData', 'V15AddTokenIssuance', 'V16MoveTokenIssuance', 'V17HashItemRecordPublicData', 'V18AddValueFee']
+    _enum: ['V1', 'V2MakeLocVoid', 'V3RequesterEnum', 'V4ItemSubmitter', 'V5Collection', 'V6ItemUpload', 'V7ItemToken', 'V8AddSeal', 'V9TermsAndConditions', 'V10AddLocFileSize', 'V11EnableEthereumSubmitter', 'V12Sponsorship', 'V13AcknowledgeItems', 'V14HashLocPublicData', 'V15AddTokenIssuance', 'V16MoveTokenIssuance', 'V17HashItemRecordPublicData', 'V18AddValueFee', 'V19AcknowledgeItemsByIssuer']
   },
   /**
    * Lookup220: pallet_logion_loc::pallet::Error<T>

--- a/packages/node-api/src/interfaces/types-lookup.ts
+++ b/packages/node-api/src/interfaces/types-lookup.ts
@@ -1997,7 +1997,8 @@ declare module '@polkadot/types/lookup' {
     readonly name: H256;
     readonly value: H256;
     readonly submitter: PalletLogionLocSupportedAccountId;
-    readonly acknowledged: bool;
+    readonly acknowledgedByOwner: bool;
+    readonly acknowledgedByVerifiedIssuer: bool;
   }
 
   /** @name PalletLogionLocFile (203) */
@@ -2006,7 +2007,8 @@ declare module '@polkadot/types/lookup' {
     readonly nature: H256;
     readonly submitter: PalletLogionLocSupportedAccountId;
     readonly size_: u32;
-    readonly acknowledged: bool;
+    readonly acknowledgedByOwner: bool;
+    readonly acknowledgedByVerifiedIssuer: bool;
   }
 
   /** @name PalletLogionLocLocType (204) */
@@ -2071,7 +2073,8 @@ declare module '@polkadot/types/lookup' {
     readonly isV16MoveTokenIssuance: boolean;
     readonly isV17HashItemRecordPublicData: boolean;
     readonly isV18AddValueFee: boolean;
-    readonly type: 'V1' | 'V2MakeLocVoid' | 'V3RequesterEnum' | 'V4ItemSubmitter' | 'V5Collection' | 'V6ItemUpload' | 'V7ItemToken' | 'V8AddSeal' | 'V9TermsAndConditions' | 'V10AddLocFileSize' | 'V11EnableEthereumSubmitter' | 'V12Sponsorship' | 'V13AcknowledgeItems' | 'V14HashLocPublicData' | 'V15AddTokenIssuance' | 'V16MoveTokenIssuance' | 'V17HashItemRecordPublicData' | 'V18AddValueFee';
+    readonly isV19AcknowledgeItemsByIssuer: boolean;
+    readonly type: 'V1' | 'V2MakeLocVoid' | 'V3RequesterEnum' | 'V4ItemSubmitter' | 'V5Collection' | 'V6ItemUpload' | 'V7ItemToken' | 'V8AddSeal' | 'V9TermsAndConditions' | 'V10AddLocFileSize' | 'V11EnableEthereumSubmitter' | 'V12Sponsorship' | 'V13AcknowledgeItems' | 'V14HashLocPublicData' | 'V15AddTokenIssuance' | 'V16MoveTokenIssuance' | 'V17HashItemRecordPublicData' | 'V18AddValueFee' | 'V19AcknowledgeItemsByIssuer';
   }
 
   /** @name PalletLogionLocError (220) */

--- a/packages/node-api/test/Queries.spec.ts
+++ b/packages/node-api/test/Queries.spec.ts
@@ -171,7 +171,8 @@ function mockPolkadotApiForLogionLoc() {
                                         toString: () => item.submitter.address
                                     }
                                 },
-                                acknowledged: mockBool(item.acknowledged),
+                                acknowledgedByOwner: mockBool(item.acknowledgedByOwner),
+                                acknowledgedByVerifiedIssuer: mockBool(item.acknowledgedByVerifiedIssuer),
                             }))
                         },
                         files: {
@@ -191,7 +192,8 @@ function mockPolkadotApiForLogionLoc() {
                                 size_: {
                                     toBigInt: () => file.size
                                 },
-                                acknowledged: mockBool(file.acknowledged),
+                                acknowledgedByOwner: mockBool(file.acknowledgedByOwner),
+                                acknowledgedByVerifiedIssuer: mockBool(file.acknowledgedByVerifiedIssuer),
                             }))
                         },
                         links: {
@@ -271,7 +273,8 @@ export const DEFAULT_LOC: LegalOfficerCase = {
             name: Hash.of("meta_name"),
             value: Hash.of("meta_value"),
             submitter: mockValidAccountId("owner"),
-            acknowledged: true,
+            acknowledgedByOwner: true,
+            acknowledgedByVerifiedIssuer: false,
         }
     ],
     files: [
@@ -280,7 +283,8 @@ export const DEFAULT_LOC: LegalOfficerCase = {
             nature: Hash.of("file-nature"),
             submitter: mockValidAccountId("owner"),
             size: BigInt(128000),
-            acknowledged: true,
+            acknowledgedByOwner: true,
+            acknowledgedByVerifiedIssuer: false,
         }
     ],
     links: [


### PR DESCRIPTION
* Companion of https://github.com/logion-network/logion-pallets/pull/34
* New attribute `acknowledgedByVerifiedIssuer` is added to metadata and files, while `acknowledged`is renamed to `acknowledgedByVerifiedIssuer`.
* Tests of `node-api` are adapted accordingly.
* `client` code is adapted _a minima_, in order to keep compilation and tests running.

Note: This [getter name change](https://github.com/logion-network/logion-pallets/pull/34/commits/42c39201356c10bef2e1931ecb1771b897254341#diff-78af5a63f1cfb1b04aed81ab8e83e04f2da8a3abf64691fcd7cf8438bd62ebb9L421) has no impact on generated code.

logion-network/logion-internal#968