### PR TITLE
Expose acknowledgedByOwner and acknowledgedByVerifiedIssuer.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.30.0-5",
+  "version": "0.30.0-7",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/test/Public.spec.ts
+++ b/packages/client/test/Public.spec.ts
@@ -77,7 +77,9 @@ describe("PublicLoc", () => {
             hash: Hash.fromHex(EXISTING_FILE.hash),
             published: true,
             size: BigInt(EXISTING_FILE.size),
-            submitter: REQUESTER
+            submitter: REQUESTER,
+            acknowledgedByOwner: false,
+            acknowledgedByVerifiedIssuer: false,
         } ]);
         data.setup(instance => instance.metadata).returns([]);
 

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.20.0-2",
+  "version": "0.20.0-4",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/interfaces/default/definitions.ts
+++ b/packages/node-api/src/interfaces/default/definitions.ts
@@ -58,7 +58,8 @@ export default {
             name: "Hash",
             value: "Hash",
             submitter: "SupportedAccountId",
-            acknowledged: "bool"
+            acknowledgedByOwner: "bool",
+            acknowledgedByVerifiedIssuer: "bool"
         },
         LocType: {
             _enum: [
@@ -80,7 +81,8 @@ export default {
             hash: "Hash",
             nature: "Hash",
             submitter: "SupportedAccountId",
-            acknowledged: "bool"
+            acknowledgedByOwner: "bool",
+            acknowledgedByVerifiedIssuer: "bool"
         },
         LocVoidInfo: {
             replacer: "Option<LocId>"

--- a/packages/node-api/src/interfaces/default/types.ts
+++ b/packages/node-api/src/interfaces/default/types.ts
@@ -89,7 +89,8 @@ export interface File extends Struct {
   readonly hash: Hash;
   readonly nature: Hash;
   readonly submitter: SupportedAccountId;
-  readonly acknowledged: bool;
+  readonly acknowledgedByOwner: bool;
+  readonly acknowledgedByVerifiedIssuer: bool;
 }
 
 /** @name FileParams */
@@ -182,7 +183,8 @@ export interface MetadataItem extends Struct {
   readonly name: Hash;
   readonly value: Hash;
   readonly submitter: SupportedAccountId;
-  readonly acknowledged: bool;
+  readonly acknowledgedByOwner: bool;
+  readonly acknowledgedByVerifiedIssuer: bool;
 }
 
 /** @name MetadataItemParams */


### PR DESCRIPTION
* Allow verified issuer to acknowledge metadata or files.
* Expose attributes `acknowledgedByOwner` and `acknowledgedByVerifiedIssuer` in metadata and files.
* `node-api`: adapt types and definitions.

logion-network/logion-internal#970