### PR TITLE
Fix transfer of tokens on recovery

### DIFF
--- a/packages/client/integration/Main.spec.ts
+++ b/packages/client/integration/Main.spec.ts
@@ -63,7 +63,7 @@ describe("Logion SDK", () => {
         await recoverLostVault(state);
     });
 
-    xit("recovers a lost account", async () => {
+    it("recovers a lost account", async () => {
         await recoverLostAccount(state);
     });
 

--- a/packages/client/integration/Recovery.ts
+++ b/packages/client/integration/Recovery.ts
@@ -91,10 +91,9 @@ export async function recoverLostAccount(state: State) {
 
     console.log("Transfer from recovered account")
     const recoveredBalance = await claimed.recoveredBalanceState();
-    await recoveredBalance.transfer({
+    await recoveredBalance.transferAll({
         signer,
         destination: NEW_ADDRESS,
-        amount: recoveredBalance.balances[0].available,
     });
 }
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.32.0-6",
+  "version": "0.32.0-7",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",


### PR DESCRIPTION
* Add `transferAll` to properly implement account emptying in case of recovery.

logion-network/logion-internal#936