### PR TITLE
Refactor hybrid back/chain commands

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.32.0-7",
+  "version": "0.32.0-8",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -1585,7 +1585,7 @@ export class OpenLoc extends EditableRequest {
     async estimateFeesPublishMetadata(parameters: { nameHash: Hash }): Promise<FeesClass> {
         const client = this.locSharedState.client;
         const metadata = this.findMetadata(parameters.nameHash, "REVIEW_ACCEPTED");
-        return client.estimatePublishMetadata(metadata);
+        return client.estimateFeesPublishMetadata(metadata);
     }
 
     async acknowledgeMetadata(parameters: AckMetadataParams): Promise<OpenLoc> {

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -1343,6 +1343,9 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async publishFile(parameters: PublishFileParams): Promise<void> {
+        const fees = await this.estimateFeesPublishFile(parameters);
+        await this.ensureEnoughFunds(fees);
+
         try {
             await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/files/${ parameters.file.hash.toHex() }/pre-publish-ack`);
         } catch(e) {
@@ -1356,10 +1359,13 @@ export class AuthenticatedLocClient extends LocClient {
         });
     }
 
-    async estimateFeesPublishFile(parameters: EstimateFeesPublishFileParams): Promise<FeesClass> {
+    private async ensureEnoughFunds(fees: FeesClass) {
+        await this.nodeApi.fees.ensureEnoughFunds({ origin: this.currentAddress.address, fees });
+    }
 
+    async estimateFeesPublishFile(parameters: EstimateFeesPublishFileParams): Promise<FeesClass> {
         return await this.nodeApi.fees.estimateWithStorage({
-            origin: this.currentAddress?.address || "",
+            origin: this.currentAddress.address,
             submittable: this.publishFileSubmittable(parameters),
             size: parameters.file.size,
         });
@@ -1373,6 +1379,9 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async acknowledgeFile(parameters: { locId: UUID } & AckFileParams): Promise<void> {
+        const fees = await this.estimateFeesAcknowledgeFile(parameters);
+        await this.ensureEnoughFunds(fees);
+
         try {
             await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/files/${ parameters.hash.toHex() }/pre-ack`);
         } catch(e) {
@@ -1388,7 +1397,7 @@ export class AuthenticatedLocClient extends LocClient {
 
     async estimateFeesAcknowledgeFile(parameters: { locId: UUID } & RefFileParams): Promise<FeesClass> {
         return await this.nodeApi.fees.estimateWithoutStorage({
-            origin: this.currentAddress?.address || "",
+            origin: this.currentAddress.address,
             submittable: this.acknowledgeFileSubmittable(parameters)
         });
     }
@@ -1423,6 +1432,9 @@ export class AuthenticatedLocClient extends LocClient {
         const { name } = parameters.metadata;
         const nameHash = Hash.of(name);
 
+        const fees = await this.estimateFeesPublishMetadata(parameters);
+        await this.ensureEnoughFunds(fees);
+
         try {
             await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/metadata/${ nameHash.toHex() }/pre-publish-ack`);
         } catch(e) {
@@ -1436,9 +1448,9 @@ export class AuthenticatedLocClient extends LocClient {
         });
     }
 
-    async estimatePublishMetadata(parameters: EstimateFeesPublishMetadataParams): Promise<FeesClass> {
+    async estimateFeesPublishMetadata(parameters: EstimateFeesPublishMetadataParams): Promise<FeesClass> {
         return await this.nodeApi.fees.estimateWithoutStorage({
-            origin: this.currentAddress?.address || "",
+            origin: this.currentAddress.address,
             submittable: this.publishMetadataSubmittable(parameters)
         });
     }
@@ -1459,6 +1471,9 @@ export class AuthenticatedLocClient extends LocClient {
     async acknowledgeMetadata(parameters: { locId: UUID } & AckMetadataParams): Promise<void> {
         const { locId, nameHash } = parameters;
 
+        const fees = await this.estimateFeesAcknowledgeMetadata(parameters);
+        await this.ensureEnoughFunds(fees);
+
         try {
             await this.backend().put(`/api/loc-request/${ locId.toString() }/metadata/${ nameHash.toHex() }/pre-ack`);
         } catch(e) {
@@ -1474,7 +1489,7 @@ export class AuthenticatedLocClient extends LocClient {
 
     async estimateFeesAcknowledgeMetadata(parameters: { locId: UUID } & RefMetadataParams): Promise<FeesClass> {
         return await this.nodeApi.fees.estimateWithoutStorage({
-            origin: this.currentAddress?.address || "",
+            origin: this.currentAddress.address,
             submittable: this.acknowledgeMetadataSubmittable(parameters)
         });
     }
@@ -1506,6 +1521,9 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async publishLink(parameters: PublishLinkParams): Promise<void> {
+        const fees = await this.estimateFeesPublishLink(parameters);
+        await this.ensureEnoughFunds(fees);
+
         try {
             await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/links/${ parameters.link.id.toString() }/pre-publish-ack`);
         } catch(e) {
@@ -1535,6 +1553,9 @@ export class AuthenticatedLocClient extends LocClient {
 
     async acknowledgeLink(parameters: { locId: UUID } & AckLinkParams): Promise<void> {
         const { locId, target } = parameters;
+
+        const fees = await this.estimateFeesAcknowledgeLink(parameters);
+        await this.ensureEnoughFunds(fees);
 
         try {
             await this.backend().put(`/api/loc-request/${ locId.toString() }/links/${ target.toString() }/pre-ack`);
@@ -1617,13 +1638,18 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async openTransactionLoc(parameters: OpenPolkadotLocParams & BlockchainSubmissionParams ) {
-        const { locId, signer, callback } = parameters
+        const { locId, signer, callback } = parameters;
+
+        const fees = await this.estimateFeesOpenTransactionLoc(parameters);
+        await this.ensureEnoughFunds(fees);
+
+        await this.openLoc({ locId });
+
         await signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.openTransactionLocSubmittable(parameters),
             callback,
         });
-        await this.openLoc({ locId });
     }
 
     private openTransactionLocSubmittable(parameters: OpenPolkadotLocParams): SubmittableExtrinsic {
@@ -1744,13 +1770,18 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async openIdentityLoc(parameters: OpenPolkadotLocParams & BlockchainSubmissionParams ) {
-        const { locId, signer, callback } = parameters
+        const { locId, signer, callback } = parameters;
+
+        const fees = await this.estimateFeesOpenIdentityLoc(parameters);
+        await this.ensureEnoughFunds(fees);
+
+        await this.openLoc({ locId });
+
         await signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.openIdentityLocSubmittable(parameters),
             callback,
         });
-        await this.openLoc({ locId });
     }
 
     private openIdentityLocSubmittable(parameters: OpenPolkadotLocParams): SubmittableExtrinsic {
@@ -1831,13 +1862,18 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async openCollectionLoc(parameters: { valueFee: bigint } & OpenPolkadotLocParams & OpenCollectionLocParams) {
-        const { locId, signer, callback } = parameters
+        const { locId, signer, callback } = parameters;
+
+        const fees = await this.estimateFeesOpenCollectionLoc(parameters);
+        await this.ensureEnoughFunds(fees);
+
+        await this.openLoc({ locId });
+
         await signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.openCollectionLocSubmittable(parameters),
             callback,
         });
-        await this.openLoc({ locId });
     }
 
     private openCollectionLocSubmittable(parameters: { valueFee: bigint } & OpenPolkadotLocParams & EstimateFeesOpenCollectionLocParams): SubmittableExtrinsic {
@@ -1860,7 +1896,7 @@ export class AuthenticatedLocClient extends LocClient {
 
     async estimateFeesOpenCollectionLoc(parameters: { valueFee: bigint } & OpenPolkadotLocParams & EstimateFeesOpenCollectionLocParams) {
         return await this.nodeApi.fees.estimateCreateLoc({
-            origin: this.currentAddress?.address || "",
+            origin: this.currentAddress.address,
             submittable: this.openCollectionLocSubmittable(parameters),
             locType: 'Collection',
             valueFee: parameters.valueFee,
@@ -1881,17 +1917,23 @@ export class AuthenticatedLocClient extends LocClient {
             );
         }
 
-        await parameters.signer.signAndSend({
-            signerId: this.currentAddress.address,
+        const fees = await this.nodeApi.fees.estimateWithoutStorage({
+            origin: this.currentAddress.address,
             submittable,
-            callback: parameters.callback,
         });
+        await this.ensureEnoughFunds(fees);
 
         try {
             await this.backend().post(`/api/loc-request/${ parameters.locId.toString() }/close`);
         } catch(e) {
             throw newBackendError(e);
         }
+
+        await parameters.signer.signAndSend({
+            signerId: this.currentAddress.address,
+            submittable,
+            callback: parameters.callback,
+        });
     }
 
     async voidLoc(parameters: { locId: UUID } & VoidParams): Promise<void> {
@@ -1908,11 +1950,12 @@ export class AuthenticatedLocClient extends LocClient {
                 this.nodeApi.adapters.toLocId(locId),
             );
         }
-        await signer.signAndSend({
-            signerId: this.currentAddress.address,
+
+        const fees = await this.nodeApi.fees.estimateWithoutStorage({
+            origin: this.currentAddress.address,
             submittable,
-            callback
         });
+        await this.ensureEnoughFunds(fees);
 
         try {
             await this.backend().post(`/api/loc-request/${ locId.toString() }/void`, {
@@ -1921,6 +1964,12 @@ export class AuthenticatedLocClient extends LocClient {
         } catch(e) {
             throw newBackendError(e);
         }
+
+        await signer.signAndSend({
+            signerId: this.currentAddress.address,
+            submittable,
+            callback
+        });
     }
 
     async nominateIssuer(parameters: { locId: UUID, requester: string } & BlockchainSubmissionParams) {

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -1343,18 +1343,17 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async publishFile(parameters: PublishFileParams): Promise<void> {
+        try {
+            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/files/${ parameters.file.hash.toHex() }/pre-publish-ack`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
 
         await parameters.signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.publishFileSubmittable(parameters),
             callback: parameters.callback,
         });
-
-        try {
-            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/files/${ parameters.file.hash.toHex() }/confirm`);
-        } catch(e) {
-            throw newBackendError(e);
-        }
     }
 
     async estimateFeesPublishFile(parameters: EstimateFeesPublishFileParams): Promise<FeesClass> {
@@ -1374,17 +1373,17 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async acknowledgeFile(parameters: { locId: UUID } & AckFileParams): Promise<void> {
+        try {
+            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/files/${ parameters.hash.toHex() }/pre-ack`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
+
         await parameters.signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.acknowledgeFileSubmittable(parameters),
             callback: parameters.callback,
         });
-
-        try {
-            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/files/${ parameters.hash.toHex() }/confirm-acknowledged`);
-        } catch(e) {
-            throw newBackendError(e);
-        }
     }
 
     async estimateFeesAcknowledgeFile(parameters: { locId: UUID } & RefFileParams): Promise<FeesClass> {
@@ -1424,17 +1423,17 @@ export class AuthenticatedLocClient extends LocClient {
         const { name } = parameters.metadata;
         const nameHash = Hash.of(name);
 
+        try {
+            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/metadata/${ nameHash.toHex() }/pre-publish-ack`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
+
         await parameters.signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.publishMetadataSubmittable(parameters),
             callback: parameters.callback,
         });
-    
-        try {
-            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/metadata/${ nameHash.toHex() }/confirm`);
-        } catch(e) {
-            throw newBackendError(e);
-        }
     }
 
     async estimatePublishMetadata(parameters: EstimateFeesPublishMetadataParams): Promise<FeesClass> {
@@ -1460,17 +1459,17 @@ export class AuthenticatedLocClient extends LocClient {
     async acknowledgeMetadata(parameters: { locId: UUID } & AckMetadataParams): Promise<void> {
         const { locId, nameHash } = parameters;
 
+        try {
+            await this.backend().put(`/api/loc-request/${ locId.toString() }/metadata/${ nameHash.toHex() }/pre-ack`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
+
         await parameters.signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.acknowledgeMetadataSubmittable(parameters),
             callback: parameters.callback,
         });
-
-        try {
-            await this.backend().put(`/api/loc-request/${ locId.toString() }/metadata/${ nameHash.toHex() }/confirm-acknowledged`);
-        } catch(e) {
-            throw newBackendError(e);
-        }
     }
 
     async estimateFeesAcknowledgeMetadata(parameters: { locId: UUID } & RefMetadataParams): Promise<FeesClass> {
@@ -1507,18 +1506,17 @@ export class AuthenticatedLocClient extends LocClient {
     }
 
     async publishLink(parameters: PublishLinkParams): Promise<void> {
+        try {
+            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/links/${ parameters.link.id.toString() }/pre-publish-ack`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
 
         await parameters.signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.publishLinkSubmittable(parameters),
             callback: parameters.callback,
         });
-
-        try {
-            await this.backend().put(`/api/loc-request/${ parameters.locId.toString() }/links/${ parameters.link.id.toString() }/confirm`);
-        } catch(e) {
-            throw newBackendError(e);
-        }
     }
 
     private publishLinkSubmittable(parameters: EstimateFeesPublishLinkParams): SubmittableExtrinsic {
@@ -1538,17 +1536,17 @@ export class AuthenticatedLocClient extends LocClient {
     async acknowledgeLink(parameters: { locId: UUID } & AckLinkParams): Promise<void> {
         const { locId, target } = parameters;
 
+        try {
+            await this.backend().put(`/api/loc-request/${ locId.toString() }/links/${ target.toString() }/pre-ack`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
+
         await parameters.signer.signAndSend({
             signerId: this.currentAddress.address,
             submittable: this.acknowledgeLinkSubmittable(parameters),
             callback: parameters.callback,
         });
-
-        try {
-            await this.backend().put(`/api/loc-request/${ locId.toString() }/links/${ target.toString() }/confirm-acknowledged`);
-        } catch(e) {
-            throw newBackendError(e);
-        }
     }
 
     async estimateFeesAcknowledgeLink(parameters: { locId: UUID } & RefLinkParams): Promise<FeesClass> {

--- a/packages/client/test/Balance.spec.ts
+++ b/packages/client/test/Balance.spec.ts
@@ -214,7 +214,7 @@ describe("Balance", () => {
                     .returns(asRecovered.object());
 
                 nodeApi.setup(instance => instance.queries.getAccountData(recoveredAddress))
-                    .returnsAsync({ available: "200", reserved: "0", total: "200" });
+                    .returnsAsync({ available: 200n, reserved: 0n, total: 200n });
 
                 setupFetchTransactions(axiosFactory, [], recoveredAddress);
             },

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -1,4 +1,4 @@
-import { Hash, LogionNodeApiClass, UUID, VerifiedIssuerType } from "@logion/node-api";
+import { Fees, Hash, LogionNodeApiClass, UUID, VerifiedIssuerType } from "@logion/node-api";
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
 import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
 import { DateTime } from "luxon";
@@ -46,7 +46,8 @@ import {
     buildSimpleNodeApi,
     buildValidPolkadotAccountId,
     ItIsUuid,
-    mockCodecWithToString
+    mockCodecWithToString,
+    mockCodecWithToBigInt
 } from "./Utils.js";
 import { TestConfigFactory } from "./TestConfigFactory.js";
 import {
@@ -223,7 +224,7 @@ describe("OpenLoc", () => {
         });
 
         signer.verify(instance => instance.signAndSend(It.IsAny()), Times.Once());
-        nodeApiMock.verify(instance => instance.polkadot.tx.logionLoc.addLink(It.IsAny(), It.IsAny()), Times.Once());
+        nodeApiMock.verify(instance => instance.polkadot.tx.logionLoc.addLink(It.IsAny(), It.IsAny()), Times.Exactly(2));
     });
 
     it("can be voided", async () => {
@@ -865,6 +866,9 @@ async function buildSharedState(isVerifiedIssuer: boolean = false): Promise<Shar
 
             const dismissIssuerExtrinsic = new Mock<SubmittableExtrinsic>();
             nodeApiMock.setup(instance => instance.polkadot.tx.logionLoc.dismissIssuer(It.IsAny())).returns(dismissIssuerExtrinsic.object());
+
+            nodeApiMock.setup(instance => instance.fees.estimateWithoutStorage(It.IsAny())).returnsAsync(new Fees({ inclusionFee: 0n }));
+            nodeApiMock.setup(instance => instance.fees.ensureEnoughFunds(It.IsAny())).returnsAsync(undefined);
         },
         currentAddress,
         legalOfficers,

--- a/packages/node-api/integration/Fees.ts
+++ b/packages/node-api/integration/Fees.ts
@@ -1,5 +1,5 @@
-import { setup } from "./Util.js";
-import { Currency } from "../src/index.js";
+import { ALICE, setup } from "./Util.js";
+import { Currency, Fees } from "../src/index.js";
 
 export async function storageFees() {
     const { api } = await setup();
@@ -24,4 +24,21 @@ export async function certificateFees() {
     const { api } = await setup();
     const certificateFee = await api.fees.estimateCertificateFee({ tokenIssuance: 1000n });
     expect(certificateFee).toEqual(Currency.toCanonicalAmount(Currency.nLgnt(4n)));
+}
+
+export async function ensureEnoughFunds() {
+    const { api } = await setup();
+
+    const accountData = await api.queries.getAccountData(ALICE);
+    const existentialDeposit = api.polkadot.consts.balances.existentialDeposit.toBigInt();
+
+    await expectAsync(testEnsureEnoughFunds(accountData.available)).toBeRejectedWithError("Not enough funds");
+    await expectAsync(testEnsureEnoughFunds(accountData.available + 1000n)).toBeRejectedWithError("Not enough funds");
+    await expectAsync(testEnsureEnoughFunds(accountData.available - existentialDeposit)).toBeResolved();
+    await expectAsync(testEnsureEnoughFunds(accountData.available - (10n * existentialDeposit))).toBeResolved();
+}
+
+async function testEnsureEnoughFunds(fees: bigint) {
+    const { api } = await setup();
+    return api.fees.ensureEnoughFunds({ fees: new Fees({ inclusionFee: fees }), origin: ALICE })
 }

--- a/packages/node-api/integration/Main.spec.ts
+++ b/packages/node-api/integration/Main.spec.ts
@@ -19,7 +19,7 @@ import {
 } from "./TransactionLoc.js";
 import { createVote } from "./Vote.js";
 import { verifiedIssuers } from "./VerifiedIssuers.js";
-import { storageFees, legalFees, certificateFees } from "./Fees.js";
+import { storageFees, legalFees, certificateFees, ensureEnoughFunds } from "./Fees.js";
 import { toPalletLogionLocOtherAccountId, toSponsorshipId, toPalletLogionLocMetadataItem, toPalletLogionLocFile, toCollectionItemToken, toCollectionItemFile } from "./Adapters.js";
 import { badOriginError, moduleError } from "./Error.js";
 
@@ -30,6 +30,7 @@ describe("Logion Node API", () => {
     it("queries file storage fees", storageFees);
     it("queries legal fees", legalFees);
     it("queries certificate fees", certificateFees);
+    it("ensures enough funds", ensureEnoughFunds);
 
     it("adapts to PalletLogionLocOtherAccountId", toPalletLogionLocOtherAccountId);
     it("adapts to SponsorshipId", toSponsorshipId);

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.22.1-3",
+  "version": "0.23.0-1",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/Adapters.ts
+++ b/packages/node-api/src/Adapters.ts
@@ -78,9 +78,9 @@ export class Adapters {
 
     fromFrameSystemAccountInfo(accountData: FrameSystemAccountInfo): TypesAccountData {
         return {
-            available: accountData.data.free.toString(),
-            reserved: accountData.data.reserved.toString(),
-            total: accountData.data.free.add(accountData.data.reserved).toString(),
+            available: accountData.data.free.toBigInt(),
+            reserved: accountData.data.reserved.toBigInt(),
+            total: BigInt(accountData.data.free.add(accountData.data.reserved).toString()),
         };
     }
 

--- a/packages/node-api/src/FeesEstimator.ts
+++ b/packages/node-api/src/FeesEstimator.ts
@@ -118,4 +118,14 @@ export class FeesEstimator {
             certificateFee,
         });
     }
+
+    async ensureEnoughFunds(params: { fees: Fees, origin: string }) {
+        const { fees, origin } = params;
+        const totalFees = fees.totalFee;
+        const accountData = await this.api.query.system.account(origin);
+        const existentialDeposit = this.api.consts.balances.existentialDeposit.toBigInt();
+        if(accountData.data.free.toBigInt() - existentialDeposit < totalFees) {
+            throw new Error("Not enough funds");
+        }
+    }
 }

--- a/packages/node-api/src/Types.ts
+++ b/packages/node-api/src/Types.ts
@@ -6,9 +6,9 @@ import { ApiPromise } from "@polkadot/api";
 import { Hash } from './Hash.js';
 
 export interface TypesAccountData {
-    available: string,
-    reserved: string,
-    total: string,
+    available: bigint,
+    reserved: bigint,
+    total: bigint,
 }
 
 export interface LocItemParams {

--- a/packages/node-api/test/Queries.spec.ts
+++ b/packages/node-api/test/Queries.spec.ts
@@ -2,6 +2,7 @@ import { ApiPromise } from "@polkadot/api";
 import { CollectionItem, Hash, LegalOfficerCase, LogionNodeApiClass, Numbers, UUID } from "../src/index.js";
 import { POLKADOT_API_CREATE_TYPE, mockValidAccountId, mockBool } from "./Util.js";
 import { DEFAULT_LEGAL_OFFICER } from "./TestData.js";
+import { BN } from "bn.js";
 
 describe("Queries", () => {
 
@@ -12,8 +13,8 @@ describe("Queries", () => {
         const logionApi = new LogionNodeApiClass(api);
         const data = await logionApi.queries.getAccountData(accountId);
     
-        expect(data.available).toBe("42");
-        expect(data.reserved).toBe("0");
+        expect(data.available).toBe(42n);
+        expect(data.reserved).toBe(0n);
     });
     
     it("Getting balances", async () => {
@@ -125,11 +126,11 @@ function mockPolkadotApiWithAccountData(accountId: string) {
                 account: (id: string) => id === accountId ? {
                     data: {
                         free: {
-                            toString: () => "42",
-                            add: () => "42",
+                            toBigInt: () => 42n,
+                            add: () => new BN("42"),
                         },
                         reserved: {
-                            toString: () => "0"
+                            toBigInt: () => 0n
                         }
                     }
                 }: undefined,


### PR DESCRIPTION
* When a command implies both a call to the backend and the submission of an extrinsic, the call to the backend should go first in order to prevent update collisions with the sync (probability is maximized now that we wait for finalization frontend-side).
* To prevent as much inconsistency as possible, one should make sure that both the call and the submission will be successful (or at least, that a successful call will followed by a successful submission).
* The SDK now checks that there are enough funds available before executing an hybrid command, which greatly reduces the chances of submission failure following a successful call.