### PR TITLE
Refactor for RN support

### DIFF
--- a/packages/client-browser/package.json
+++ b/packages/client-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-browser",
-  "version": "0.1.0",
+  "version": "0.2.0-1",
   "description": "logion SDK for client applications running in a browser",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client-browser/src/index.ts
+++ b/packages/client-browser/src/index.ts
@@ -1,11 +1,11 @@
 import { Hash as Hasher } from 'fast-sha256';
-import { AxiosFileUploader, File, FormDataLike, HashAndSize } from "@logion/client";
+import { AxiosFileUploader, File, FormDataLike, HashAndSize, MimeType } from "@logion/client";
 import { Hash } from "@logion/node-api";
 
 export class BrowserFile extends File {
 
-    constructor(file: Blob) {
-        super();
+    constructor(file: Blob, name: string) {
+        super(name, MimeType.from(file.type));
         this.file = file;
     }
 

--- a/packages/client-browser/test/index.spec.ts
+++ b/packages/client-browser/test/index.spec.ts
@@ -7,7 +7,8 @@ const TEST_HASH = Hash.fromHex("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b82
 describe("BrowserFile", () => {
 
     it("gets hash and size", async () => {
-        const file = new BrowserFile(BLOB_MOCK);
+        const file = new BrowserFile(BLOB_MOCK, "test.txt");
+        expect(file.mimeType.mimeType).toBe("text/plain")
         const hashSize = await file.getHashAndSize();
         expect(hashSize.hash).toEqual(TEST_HASH);
         expect(hashSize.size).toBe(4n);
@@ -33,4 +34,6 @@ const STREAM_MOCK = new Mock<any>()
 const BLOB_MOCK = new Mock<Blob>()
     .setup(instance => instance.stream())
     .returns(STREAM_MOCK)
+    .setup(instance => instance.type)
+    .returns("text/plain")
     .object();

--- a/packages/client-node/integration/DirectLocOpen.ts
+++ b/packages/client-node/integration/DirectLocOpen.ts
@@ -18,7 +18,8 @@ import {
     MergedLink,
     LocData,
     OpenLoc,
-    waitFor
+    waitFor,
+    MimeType
 } from "@logion/client";
 import { UUID } from "@logion/node-api";
 
@@ -156,14 +157,12 @@ function provideItems(name: string, linkedLocs: UUID[]): ItemsParams {
     return {
         files: [
             {
-                fileName: `${ name }-1.txt`,
                 nature: "Some file nature",
-                file: HashOrContent.fromContent(new NodeFile(`integration/${ name }-1.txt`)),
+                file: HashOrContent.fromContent(new NodeFile(`integration/${ name }-1.txt`, `${ name }-1.txt`, MimeType.from("text/plain"))),
             },
             {
-                fileName: `${ name }-2.txt`,
                 nature: "Some other file nature",
-                file: HashOrContent.fromContent(new NodeFile(`integration/${ name }-2.txt`)),
+                file: HashOrContent.fromContent(new NodeFile(`integration/${ name }-2.txt`, `${ name }-2.txt`, MimeType.from("text/plain"))),
             },
         ],
         metadata: [
@@ -188,7 +187,7 @@ function checkFile(actual: MergedFile, expected: AddFileParams) {
     expect(actual.status).toEqual("PUBLISHED");
     expect(actual.submitter.address).toEqual(DIRECT_REQUESTER_ADDRESS);
     expect(actual.submitter.type).toEqual("Polkadot");
-    expect(actual.name).toEqual(expected.fileName);
+    expect(actual.name).toEqual(expected.file.content.name);
     expect(actual.nature.validValue()).toEqual(expected.nature);
     expect(actual.hash).toEqual(expected.file.contentHash);
 }

--- a/packages/client-node/integration/Loc.ts
+++ b/packages/client-node/integration/Loc.ts
@@ -1,7 +1,6 @@
 import { UUID, Hash } from "@logion/node-api";
 import {
     HashOrContent,
-    ItemFileWithContent,
     MimeType,
     LocRequestStatus,
     OpenLoc,
@@ -116,9 +115,8 @@ export async function requestTransactionLoc(state: State, linkTarget: UUID): Pro
 
     // Add file to open LOC
     openLoc = await openLoc.addFile({
-        fileName: "test.txt",
         nature: "Some file nature",
-        file: HashOrContent.fromContent(new NodeFile("integration/test.txt")),
+        file: HashOrContent.fromContent(new NodeFile("integration/test.txt", "test.txt", MimeType.from("text/plain"))),
     }) as OpenLoc;
     const hash = openLoc.data().files[0].hash;
     expect(hash.toHex()).toBe("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
@@ -247,15 +245,13 @@ export async function openTransactionLocWithAutoPublish(state: State, linkTarget
 
     // Add files
     draftRequest = await draftRequest.addFile({
-        fileName: "test.txt",
         nature: "Some file nature",
-        file: HashOrContent.fromContent(new NodeFile("integration/test0.txt")),
+        file: HashOrContent.fromContent(new NodeFile("integration/test0.txt", "test.txt", MimeType.from("text/plain"))),
     }) as DraftRequest;
     const hash0 = draftRequest.data().files[0].hash;
     draftRequest = await draftRequest.addFile({
-        fileName: "test.txt",
         nature: "Some file nature",
-        file: HashOrContent.fromContent(new NodeFile("integration/test123.txt")),
+        file: HashOrContent.fromContent(new NodeFile("integration/test123.txt", "test.txt", MimeType.from("text/plain"))),
     }) as DraftRequest;
     const hash1 = draftRequest.data().files[1].hash;
 
@@ -497,11 +493,7 @@ export async function collectionLocWithUpload(state: State) {
         itemDescription: firstItemDescription,
         signer: state.signer,
         itemFiles: [
-            new ItemFileWithContent({
-                name: "test.txt",
-                contentType: MimeType.from("text/plain"),
-                hashOrContent: HashOrContent.fromContent(new NodeFile("integration/test.txt")), // Let SDK compute hash and size
-            })
+            HashOrContent.fromContent(new NodeFile("integration/test.txt", "test.txt", MimeType.from("text/plain"))), // Let SDK compute hash and size
         ],
         itemToken: firstItemToken,
         restrictedDelivery: true,
@@ -535,19 +527,19 @@ export async function collectionLocWithUpload(state: State) {
 
     const secondItemId = Hash.of("second-collection-item");
     const secondItemDescription = "Second collection item";
-    const secondFile = new NodeFile("integration/test2.txt");
+    const secondFile = new NodeFile("integration/test2.txt", "test2.txt", MimeType.from("text/plain"));
     const secondFileHash = Hash.of("test2");
     closedLoc = await closedLoc.addCollectionItem({
         itemId: secondItemId,
         itemDescription: secondItemDescription,
         signer: state.signer,
         itemFiles: [
-            new ItemFileWithContent({
+            HashOrContent.fromDescription({
                 name: "test2.txt",
-                contentType: MimeType.from("text/plain"),
-                hashOrContent: HashOrContent.fromHash(secondFileHash), // No content, must upload later
+                mimeType: MimeType.from("text/plain"),
+                hash: secondFileHash, // No content, must upload later
                 size: 5n, // No content, must provide size
-            })
+            }),
         ],
         creativeCommons: new CreativeCommons(creativeCommonsLocRequest.locId, "BY-NC-SA")
     });
@@ -561,12 +553,7 @@ export async function collectionLocWithUpload(state: State) {
 
     closedLoc = await closedLoc.uploadCollectionItemFile({
         itemId: secondItemId,
-        itemFile: new ItemFileWithContent({
-            name: "test2.txt",
-            contentType: MimeType.from("text/plain"),
-            hashOrContent: new HashOrContent({ hash: secondFileHash, content: secondFile }), // Provide both hash and content to double-check
-            size: 5n, // Provide size to double-check with content
-        })
+        itemFile: HashOrContent.fromContent(secondFile),
     });
 
     const secondItemWithUpload = await closedLoc.getCollectionItem({ itemId: secondItemId });

--- a/packages/client-node/integration/TokensRecord.ts
+++ b/packages/client-node/integration/TokensRecord.ts
@@ -2,7 +2,6 @@ import { Hash } from "@logion/node-api";
 import {
     ClosedCollectionLoc,
     HashOrContent,
-    ItemFileWithContent,
     LocRequestState,
     MimeType,
     PendingRequest,
@@ -48,11 +47,7 @@ export async function tokensRecords(state: State) {
         recordId,
         description: recordDescription,
         files: [
-            new ItemFileWithContent({
-                name: "report.txt",
-                contentType: MimeType.from("text/plain"),
-                hashOrContent: HashOrContent.fromContent(new NodeFile("integration/test.txt")),
-            })
+            HashOrContent.fromContent(new NodeFile("integration/test.txt", "report.txt", MimeType.from("text/plain"))),
         ],
     });
     expect(estimatedFees.tokensRecordFee).toBe(tokensRecordFee);
@@ -60,11 +55,7 @@ export async function tokensRecords(state: State) {
         recordId,
         description: recordDescription,
         files: [
-            new ItemFileWithContent({
-                name: "report.txt",
-                contentType: MimeType.from("text/plain"),
-                hashOrContent: HashOrContent.fromContent(new NodeFile("integration/test.txt")),
-            })
+            HashOrContent.fromContent(new NodeFile("integration/test.txt", "report.txt", MimeType.from("text/plain"))),
         ],
         signer: state.signer,
     });

--- a/packages/client-node/integration/VerifiedIssuer.ts
+++ b/packages/client-node/integration/VerifiedIssuer.ts
@@ -3,7 +3,7 @@ import {
     ClosedLoc,
     HashOrContent,
     AcceptedRequest,
-    PendingRequest, OpenLoc
+    PendingRequest, OpenLoc, MimeType
 } from "@logion/client";
 import { State, ISSUER_ADDRESS, initRequesterBalance, TEST_LOGION_CLIENT_CONFIG } from "./Utils.js";
 import { NodeFile } from "../src/index.js";
@@ -86,9 +86,8 @@ export async function verifiedIssuer(state: State) {
     }) as OpenLoc;
     openIssuerLoc = await openIssuerLoc.deleteMetadata({ nameHash: dataNameHash }) as OpenLoc;
 
-    const file = HashOrContent.fromContent(new NodeFile("integration/test.txt"));
+    const file = HashOrContent.fromContent(new NodeFile("integration/test.txt", "test.txt", MimeType.from("text/plain")));
     openIssuerLoc = await openIssuerLoc.addFile({
-        fileName: "test.txt",
         nature: "Some file nature",
         file,
     }) as OpenLoc;

--- a/packages/client-node/package.json
+++ b/packages/client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-node",
-  "version": "0.1.0",
+  "version": "0.2.0-1",
   "description": "logion SDK for Node.JS client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client-node/src/index.ts
+++ b/packages/client-node/src/index.ts
@@ -1,4 +1,4 @@
-import { File, HashAndSize, AxiosFileUploader, FormDataLike } from "@logion/client";
+import { File, HashAndSize, AxiosFileUploader, FormDataLike, MimeType } from "@logion/client";
 import { Hash } from "@logion/node-api";
 import { Hash as Hasher } from 'fast-sha256';
 import FormData from "form-data";
@@ -6,8 +6,8 @@ import fs from "fs";
 
 export class NodeFile extends File {
 
-    constructor(path: string) {
-        super();
+    constructor(path: string, name: string, mimeType: MimeType) {
+        super(name, mimeType);
         this.path = path;
     }
 

--- a/packages/client-node/test/index.spec.ts
+++ b/packages/client-node/test/index.spec.ts
@@ -1,12 +1,13 @@
 import { Hash } from "@logion/node-api";
 import { NodeFile } from "../src/index.js";
+import { MimeType } from "@logion/client";
 
 const TEST_HASH = Hash.fromHex("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
 
 describe("NodeFile", () => {
 
     it("gets hash and size", async () => {
-        const file = new NodeFile("test/file.txt");
+        const file = new NodeFile("test/file.txt", "file.txt", MimeType.from("text/plain"));
         const hashSize = await file.getHashAndSize();
         expect(hashSize.hash).toEqual(TEST_HASH);
         expect(hashSize.size).toBe(4n);

--- a/packages/client-react-native-fs/package.json
+++ b/packages/client-react-native-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-react-native-fs",
-  "version": "0.1.0-1",
+  "version": "0.1.0-11",
   "description": "logion SDK for client applications running in a React Native app using react-native-fs",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.34.0",
+  "version": "0.35.0-1",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/ComponentFactory.ts
+++ b/packages/client/src/ComponentFactory.ts
@@ -7,6 +7,7 @@ import { LegalOfficerEndpoint } from "./SharedClient.js";
 import { LegalOfficerClass } from "./Types.js";
 import axios from "axios";
 import { newBackendError } from "./Error.js";
+import { MimeType } from "./Mime.js";
 
 export interface HashAndSize {
     hash: Hash;
@@ -14,6 +15,14 @@ export interface HashAndSize {
 }
 
 export abstract class File {
+
+    constructor(name: string, mimeType: MimeType) {
+        this.name = name;
+        this.mimeType = mimeType;
+    }
+
+    readonly name: string;
+    readonly mimeType: MimeType;
 
     abstract getHashAndSize(): Promise<HashAndSize>;
 }
@@ -27,7 +36,6 @@ export interface FileUploadParameters {
 
 export interface FileToUpload {
     file: File;
-    name: string;
     field: string;
 }
 
@@ -49,7 +57,7 @@ export abstract class AxiosFileUploader implements FileUploader {
     async upload(parameters: FileUploadParameters): Promise<void> {
         const formData = this.buildFormData();
         for(const file of parameters.files) {
-            formData.append(file.field, await this.toFormDataValue(file.file), file.name);
+            formData.append(file.field, await this.toFormDataValue(file.file), file.file.name);
         }
         for(const field of parameters.fields) {
             formData.append(field.name, field.value);

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -22,7 +22,6 @@ import {
     AddCollectionItemParams,
     LocRequestVoidInfo,
     LocRequestStatus,
-    ItemFileWithContent,
     AuthenticatedLocClient,
     FetchAllLocsParams,
     IdenfyVerificationSession,
@@ -69,6 +68,7 @@ import { Fees } from "./Fees.js";
 import { HashString, HashOrContent } from "./Hash.js";
 import { DateTime } from "luxon";
 import { fromIsoString } from "./DateTimeUtil.js";
+import { MimeType } from "./Mime.js";
 
 export interface LocData extends LocVerifiedIssuers {
     id: UUID
@@ -1484,8 +1484,12 @@ export class AcceptedRequest extends ReviewedRequest {
     private toAddFileParams(autoPublish: boolean): AddFileParams[] {
         if (autoPublish) {
             return this.request.files.filter(item => item.status === "REVIEW_ACCEPTED").map(item => ({
-                file: HashOrContent.fromHashAndSize(Hash.fromHex(item.hash), BigInt(item.size)),
-                fileName: item.name,
+                file: HashOrContent.fromDescription({
+                    name: item.name,
+                    hash: Hash.fromHex(item.hash),
+                    size: BigInt(item.size),
+                    mimeType: MimeType.from(item.contentType),
+                }),
                 nature: item.nature,
             }));
         } else {
@@ -2214,12 +2218,12 @@ abstract class ClosedOrVoidCollectionLoc extends LocRequestState {
 
 export interface UploadCollectionItemFileParams {
     itemId: Hash,
-    itemFile: ItemFileWithContent,
+    itemFile: HashOrContent,
 }
 
 export interface UploadTokensRecordFileParams {
     recordId: Hash,
-    file: ItemFileWithContent,
+    file: HashOrContent,
 }
 
 export class ClosedCollectionLoc extends ClosedOrVoidCollectionLoc {

--- a/packages/client/test/Hash.spec.ts
+++ b/packages/client/test/Hash.spec.ts
@@ -1,15 +1,15 @@
 import { Hash } from "@logion/node-api";
 import { HashOrContent, HashString } from "../src/index.js";
-import { MOCK_FILE, MOCK_FILE_HASH } from "./Utils.js";
+import { MOCK_FILE, MOCK_FILE_DESCRIPTION, MOCK_FILE_HASH } from "./Utils.js";
 
 describe("HashOrContent", () => {
 
-    it("does not need finalize with hash", () => {
-        const hash = HashOrContent.fromHash(MOCK_FILE_HASH);
+    it("does not need finalize with description for size", () => {
+        const hash = HashOrContent.fromDescription(MOCK_FILE_DESCRIPTION);
         expect(hash.hasContent).toBe(false);
         expect(hash.contentHash).toEqual(MOCK_FILE_HASH);
         expect(() => hash.content).toThrow();
-        expect(() => hash.size).toThrow();
+        expect(() => hash.size).not.toThrow();
     });
 
     it("finalizes from file", async () => {
@@ -18,22 +18,7 @@ describe("HashOrContent", () => {
         expect(content.hasContent).toBe(true);
         expect(content.size).toBe(4n);
     });
-
-    it("finalizes with matching hash and content", async () => {
-        const content = new HashOrContent({ hash: MOCK_FILE_HASH, content: MOCK_FILE });
-        await content.finalize();
-        expect(content.contentHash).toEqual(MOCK_FILE_HASH);
-        expect(content.hasContent).toBe(true);
-        expect(content.size).toBe(4n);
-    });
-
-    it("does not finalize with mismatching hash and content", async () => {
-        const content = new HashOrContent({ hash: WRONG_HASH, content: MOCK_FILE });
-        await expectAsync(content.finalize()).toBeRejected();
-    });
 });
-
-const WRONG_HASH = Hash.fromHex("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a09");
 
 describe("HashString", () => {
 

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -1,6 +1,6 @@
 import { Fees, Hash, LogionNodeApiClass, UUID, VerifiedIssuerType } from "@logion/node-api";
 import type { SubmittableExtrinsic } from '@polkadot/api/promise/types';
-import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from "axios";
+import { AxiosInstance, AxiosResponse } from "axios";
 import { DateTime } from "luxon";
 import { It, Mock, Times } from "moq.ts";
 
@@ -8,7 +8,6 @@ import {
     AccountTokens,
     HashOrContent,
     LegalOfficer,
-    MimeType,
     ClosedCollectionLoc,
     ClosedLoc,
     LocData,
@@ -22,7 +21,6 @@ import {
     AddMetadataParams,
     FetchLocRequestSpecification,
     FetchParameters,
-    ItemFileWithContent,
     LocRequest,
     Signer,
     SignParameters,
@@ -32,7 +30,6 @@ import {
     EditableRequest,
     LogionClient,
     SharedState,
-    FormDataLike,
     LegalOfficerClass,
     FileUploader,
     FileUploadParameters,
@@ -441,11 +438,7 @@ describe("ClosedCollectionLoc", () => {
 
         await closedLoc.uploadCollectionItemFile({
             itemId: ITEM_ID,
-            itemFile: new ItemFileWithContent({
-                name: "test.txt",
-                contentType: MimeType.from("text/plain"),
-                hashOrContent: HashOrContent.fromContent(MOCK_FILE),
-            }),
+            itemFile: HashOrContent.fromContent(MOCK_FILE),
         });
 
         uploaderMock.verify(instance => instance.upload(It.Is<FileUploadParameters>(params => 
@@ -498,11 +491,7 @@ describe("ClosedCollectionLoc", () => {
 
         await closedLoc.uploadTokensRecordFile({
             recordId: RECORD_ID,
-            file: new ItemFileWithContent({
-                name: "test.txt",
-                contentType: MimeType.from("text/plain"),
-                hashOrContent: HashOrContent.fromContent(MOCK_FILE),
-            }),
+            file: HashOrContent.fromContent(MOCK_FILE),
         });
 
         uploaderMock.verify(instance => instance.upload(It.Is<FileUploadParameters>(params => 
@@ -650,11 +639,7 @@ const CREATIVE_COMMONS: CreativeCommons = new CreativeCommons(new UUID(), "BY-SA
 
 const RECORD_ID = Hash.fromHex("0x186bf67f32bb45187a1c50286dbd9adf8751874831aeba2a66760a74a9c898cc");
 const RECORD_DESCRIPTION = "Some record description";
-const RECORD_FILES: ItemFileWithContent[] = [new ItemFileWithContent({
-    name: "test.txt",
-    contentType: MimeType.from("text/plain"),
-    hashOrContent: HashOrContent.fromContent(MOCK_FILE),
-})];
+const RECORD_FILES: HashOrContent[] = [ HashOrContent.fromContent(MOCK_FILE) ];
 
 let aliceAxiosMock: Mock<AxiosInstance>;
 let bobAxiosMock: Mock<AxiosInstance>;
@@ -990,7 +975,6 @@ async function testAddMetadata(editable: EditableRequest) {
 async function testAddFile(editable: EditableRequest) {
     let newState = await editable.addFile({
         file: HashOrContent.fromContent(MOCK_FILE),
-        fileName: "test.txt",
         nature: "Some nature",
     });
 

--- a/packages/client/test/LogionClient.spec.ts
+++ b/packages/client/test/LogionClient.spec.ts
@@ -3,7 +3,6 @@ import { It, Mock, Times } from 'moq.ts';
 import { TestConfigFactory } from './TestConfigFactory.js';
 import {
     HashOrContent,
-    ItemFileWithContent,
     MimeType,
     AuthenticationClient,
     LogionClient,
@@ -180,60 +179,5 @@ describe("LogionClient", () => {
         const client = authenticatedClient.logout();
 
         expect(client).toBeDefined();
-    });
-});
-
-describe("ItemFileWithContent", () => {
-
-    it("can be created with file size and no content", async () => {
-        const item = new ItemFileWithContent({
-            name: "test.txt",
-            contentType: MimeType.from("text/plain"),
-            hashOrContent: HashOrContent.fromHash(Hash.fromHex("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")),
-            size: 4n,
-        });
-        expect(item.name).toBe("test.txt");
-        expect(item.contentType.mimeType).toBe("text/plain");
-        expect(item.size).toBe(4n);
-        expect(item.hashOrContent).toBeDefined();
-    });
-
-    it("detects file size with content", async () => {
-        const item = new ItemFileWithContent({
-            name: "test.txt",
-            contentType: MimeType.from("text/plain"),
-            hashOrContent: HashOrContent.fromContent(MOCK_FILE),
-        });
-        await item.finalize();
-        expect(item.size).toBe(4n);
-    });
-
-    it("accepts file size matching content", async () => {
-        const item = new ItemFileWithContent({
-            name: "test.txt",
-            contentType: MimeType.from("text/plain"),
-            hashOrContent: HashOrContent.fromContent(MOCK_FILE),
-            size: 4n,
-        });
-        await item.finalize();
-        expect(item.size).toBe(4n);
-    });
-
-    it("fails at finalizing with file size not matching content", async () => {
-        const item = new ItemFileWithContent({
-            name: "test.txt",
-            contentType: MimeType.from("text/plain"),
-            hashOrContent: HashOrContent.fromContent(MOCK_FILE),
-            size: 5n,
-        });
-        await expectAsync(item.finalize()).toBeRejected();
-    });
-
-    it("cannot be created with missing file size and no content", async () => {
-        expect(() => new ItemFileWithContent({
-            name: "test.txt",
-            contentType: MimeType.from("text/plain"),
-            hashOrContent: HashOrContent.fromHash(Hash.fromHex("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")),
-        })).toThrow();
     });
 });

--- a/packages/client/test/Utils.ts
+++ b/packages/client/test/Utils.ts
@@ -18,7 +18,9 @@ import {
     SignParameters,
     FileUploader,
     HashAndSize,
-    File
+    File,
+    MimeType,
+    FileDescription
 } from "../src/index.js";
 import { TestConfigFactory } from "./TestConfigFactory.js";
 import { It, Mock } from "moq.ts";
@@ -256,7 +258,18 @@ export function mockSigner(args: {
 
 export const MOCK_FILE_HASH = Hash.fromHex("0x9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08");
 
+export const MOCK_FILE_DESCRIPTION: FileDescription = {
+    name: "test.txt",
+    hash: MOCK_FILE_HASH,
+    mimeType: MimeType.from("text/plain"),
+    size: 4n,
+};
+
 export class MockFile extends File {
+
+    constructor() {
+        super(MOCK_FILE_DESCRIPTION.name, MOCK_FILE_DESCRIPTION.mimeType);
+    }
 
     async getHashAndSize(): Promise<HashAndSize> {
         return {


### PR DESCRIPTION
* React Native upload requires `File` to expose file name and MIME type, these are added as read-only properties.
* This change leads to a refactoring of `HashOrContent` and the removal of `ItemFileWithContent`.

logion-network/logion-internal#1064