### PR TITLE
Upgrade to polkadot-v1.2.0

### DIFF
--- a/packages/client-node/integration/Balance.ts
+++ b/packages/client-node/integration/Balance.ts
@@ -11,14 +11,14 @@ export async function transfers(state: State) {
     const aliceClient = client.withCurrentAddress(aliceAccount)
     let aliceState = await aliceClient.balanceState();
 
-    checkBalance(aliceState, "99.99k");
+    checkBalance(aliceState, "100.00k");
     expect(aliceState.transactions.length).toBe(0);
     aliceState = await aliceState.transfer({
         signer,
         amount: new Numbers.PrefixedNumber("5", Numbers.KILO),
         destination: REQUESTER_ADDRESS
     });
-    checkBalance(aliceState, "94.99k");
+    checkBalance(aliceState, "95.00k");
     aliceState = await waitFor({
         producer: async state => state ? await state.refresh() : aliceState,
         predicate: state => state.transactions.length === 2,
@@ -41,7 +41,7 @@ export async function transfers(state: State) {
 
     // Alice checks her balance.
     aliceState = await aliceState.refresh();
-    checkBalance(aliceState, "96.99k");
+    checkBalance(aliceState, "97.00k");
 }
 
 export function checkBalance(balanceState: BalanceState, expectedValue: string) {

--- a/packages/client-node/integration/Fees.ts
+++ b/packages/client-node/integration/Fees.ts
@@ -4,7 +4,7 @@ import { State, REQUESTER_ADDRESS } from "./Utils.js";
 export async function fees(state: State) {
     const client = state.client;
     const api = client.logionApi;
-    const submittable = api.polkadot.tx.balances.transfer(ALICE, "10000000");
+    const submittable = api.polkadot.tx.balances.transferAllowDeath(ALICE, "10000000");
     const fees = await client.public.fees.estimateWithoutStorage({ origin: REQUESTER_ADDRESS, submittable });
     expect(fees.totalFee).toBe(3085311440000000n);
 }

--- a/packages/client-node/integration/Utils.ts
+++ b/packages/client-node/integration/Utils.ts
@@ -131,7 +131,7 @@ async function transferTokens(config: LogionClientConfig, signer: Signer, source
     const api = await buildApiClass(config.rpcEndpoints);
     await signer.signAndSend({
         signerId: source,
-        submittable: api.polkadot.tx.balances.transfer(destination, amount)
+        submittable: api.polkadot.tx.balances.transferAllowDeath(destination, amount)
     });
 }
 

--- a/packages/node-api/integration/VerifiedIssuers.ts
+++ b/packages/node-api/integration/VerifiedIssuers.ts
@@ -7,7 +7,7 @@ export async function verifiedIssuers() {
     const issuerIdentityLocId = new UUID();
     const collectionLocId = new UUID();
     await signAndSend(alice,
-        api.polkadot.tx.balances.transfer(ISSUER, Currency.toCanonicalAmount(Currency.nLgnt(200n))),
+        api.polkadot.tx.balances.transferAllowDeath(ISSUER, Currency.toCanonicalAmount(Currency.nLgnt(200n))),
     );
     await signAndSend(issuer,
         api.polkadot.tx.logionLoc.createPolkadotIdentityLoc(

--- a/packages/node-api/src/VaultClass.ts
+++ b/packages/node-api/src/VaultClass.ts
@@ -82,7 +82,7 @@ export class Vault {
         cancelVaultTransfer: (parameters: CancelVaultOutTransferParameters): SubmittableExtrinsic => {
             const { amount, destination, block, index } = parameters;
             const actualAmount = Currency.toCanonicalAmount(amount);
-            const call = this.api.tx.balances.transfer(destination, actualAmount);
+            const call = this.api.tx.balances.transferAllowDeath(destination, actualAmount);
             const sortedLegalOfficers = [ ...this.legalOfficers ].sort();
             return this.api.tx.multisig.cancelAsMulti(Vault.THRESHOLD, sortedLegalOfficers, { height: block, index }, call.method.hash)
         },
@@ -92,7 +92,7 @@ export class Vault {
         amount: bigint,
         destination: string,
     ): Promise<{ submittable: SubmittableExtrinsic, weight: Weight }> {
-        const submittable = this.api.tx.balances.transfer(destination, amount);
+        const submittable = this.api.tx.balances.transferAllowDeath(destination, amount);
         const dispatchInfo = await submittable.paymentInfo(this.address);
         const weight = dispatchInfo.weight;
         return {

--- a/packages/node-api/src/interfaces/augment-api-consts.ts
+++ b/packages/node-api/src/interfaces/augment-api-consts.ts
@@ -295,10 +295,12 @@ declare module '@polkadot/api-base/types/consts' {
     };
     timestamp: {
       /**
-       * The minimum period between blocks. Beware that this is different to the *expected*
-       * period that the block production apparatus provides. Your chosen consensus system will
-       * generally work with this to determine a sensible block time. e.g. For Aura, it will be
-       * double this period on default settings.
+       * The minimum period between blocks.
+       * 
+       * Be aware that this is different to the *expected* period that the block production
+       * apparatus provides. Your chosen consensus system will generally work with this to
+       * determine a sensible block time. For example, in the Aura pallet it will be double this
+       * period on default settings.
        **/
       minimumPeriod: u64 & AugmentedConst<ApiType>;
       /**

--- a/packages/node-api/src/interfaces/augment-api-events.ts
+++ b/packages/node-api/src/interfaces/augment-api-events.ts
@@ -449,15 +449,15 @@ declare module '@polkadot/api-base/types/events' {
     };
     sudo: {
       /**
-       * The \[sudoer\] just switched identity; the old key is supplied if one existed.
+       * The sudo key has been updated.
        **/
       KeyChanged: AugmentedEvent<ApiType, [oldSudoer: Option<AccountId32>], { oldSudoer: Option<AccountId32> }>;
       /**
-       * A sudo just took place. \[result\]
+       * A sudo call just took place.
        **/
       Sudid: AugmentedEvent<ApiType, [sudoResult: Result<Null, SpRuntimeDispatchError>], { sudoResult: Result<Null, SpRuntimeDispatchError> }>;
       /**
-       * A sudo just took place. \[result\]
+       * A [sudo_as](Pallet::sudo_as) call just took place.
        **/
       SudoAsDone: AugmentedEvent<ApiType, [sudoResult: Result<Null, SpRuntimeDispatchError>], { sudoResult: Result<Null, SpRuntimeDispatchError> }>;
       /**

--- a/packages/node-api/src/interfaces/augment-api-query.ts
+++ b/packages/node-api/src/interfaces/augment-api-query.ts
@@ -446,11 +446,14 @@ declare module '@polkadot/api-base/types/storage' {
     };
     timestamp: {
       /**
-       * Did the timestamp get updated in this block?
+       * Whether the timestamp has been updated in this block.
+       * 
+       * This value is updated to `true` upon successful submission of a timestamp by a node.
+       * It is then checked at the end of each block execution in the `on_finalize` hook.
        **/
       didUpdate: AugmentedQuery<ApiType, () => Observable<bool>, []> & QueryableStorageEntry<ApiType, []>;
       /**
-       * Current time for the current block.
+       * The current time for the current block.
        **/
       now: AugmentedQuery<ApiType, () => Observable<u64>, []> & QueryableStorageEntry<ApiType, []>;
       /**

--- a/packages/node-api/src/interfaces/augment-api-runtime.ts
+++ b/packages/node-api/src/interfaces/augment-api-runtime.ts
@@ -5,7 +5,7 @@
 // this is required to allow for ambient/previous definitions
 import '@polkadot/api-base/types/calls';
 
-import type { LocType, TokenIssuance } from '@logion/node-api/dist/interfaces/default';
+import type { TokenIssuance } from '@logion/node-api/dist/interfaces/default';
 import type { ApiTypes, AugmentedCall, DecoratedCallBase } from '@polkadot/api-base/types';
 import type { Bytes, Null, Option, Vec, u32 } from '@polkadot/types-codec';
 import type { AnyNumber, ITuple } from '@polkadot/types-codec/types';

--- a/packages/node-api/src/interfaces/augment-api-tx.ts
+++ b/packages/node-api/src/interfaces/augment-api-tx.ts
@@ -165,14 +165,6 @@ declare module '@polkadot/api-base/types/submittable' {
        **/
       forceUnreserve: AugmentedSubmittable<(who: MultiAddress | { Id: any } | { Index: any } | { Raw: any } | { Address32: any } | { Address20: any } | string | Uint8Array, amount: u128 | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [MultiAddress, u128]>;
       /**
-       * See [`Pallet::set_balance_deprecated`].
-       **/
-      setBalanceDeprecated: AugmentedSubmittable<(who: MultiAddress | { Id: any } | { Index: any } | { Raw: any } | { Address32: any } | { Address20: any } | string | Uint8Array, newFree: Compact<u128> | AnyNumber | Uint8Array, oldReserved: Compact<u128> | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [MultiAddress, Compact<u128>, Compact<u128>]>;
-      /**
-       * See [`Pallet::transfer`].
-       **/
-      transfer: AugmentedSubmittable<(dest: MultiAddress | { Id: any } | { Index: any } | { Raw: any } | { Address32: any } | { Address20: any } | string | Uint8Array, value: Compact<u128> | AnyNumber | Uint8Array) => SubmittableExtrinsic<ApiType>, [MultiAddress, Compact<u128>]>;
-      /**
        * See [`Pallet::transfer_all`].
        **/
       transferAll: AugmentedSubmittable<(dest: MultiAddress | { Id: any } | { Index: any } | { Raw: any } | { Address32: any } | { Address20: any } | string | Uint8Array, keepAlive: bool | boolean | Uint8Array) => SubmittableExtrinsic<ApiType>, [MultiAddress, bool]>;

--- a/packages/node-api/src/interfaces/default/definitions.ts
+++ b/packages/node-api/src/interfaces/default/definitions.ts
@@ -121,6 +121,7 @@ export default {
                 "V19AcknowledgeItemsByIssuer",
                 "V20AddCustomLegalFee",
                 "V21EnableRequesterLinks",
+                "V22AddRecurrentFees",
             ]
         },
         Requester: {

--- a/packages/node-api/src/interfaces/lookup.ts
+++ b/packages/node-api/src/interfaces/lookup.ts
@@ -800,11 +800,7 @@ export default {
         dest: 'MultiAddress',
         value: 'Compact<u128>',
       },
-      set_balance_deprecated: {
-        who: 'MultiAddress',
-        newFree: 'Compact<u128>',
-        oldReserved: 'Compact<u128>',
-      },
+      __Unused1: 'Null',
       force_transfer: {
         source: 'MultiAddress',
         dest: 'MultiAddress',
@@ -825,10 +821,7 @@ export default {
       upgrade_accounts: {
         who: 'Vec<AccountId32>',
       },
-      transfer: {
-        dest: 'MultiAddress',
-        value: 'Compact<u128>',
-      },
+      __Unused7: 'Null',
       force_set_balance: {
         who: 'MultiAddress',
         newFree: 'Compact<u128>'

--- a/packages/node-api/src/interfaces/types-lookup.ts
+++ b/packages/node-api/src/interfaces/types-lookup.ts
@@ -868,12 +868,6 @@ declare module '@polkadot/types/lookup' {
       readonly dest: MultiAddress;
       readonly value: Compact<u128>;
     } & Struct;
-    readonly isSetBalanceDeprecated: boolean;
-    readonly asSetBalanceDeprecated: {
-      readonly who: MultiAddress;
-      readonly newFree: Compact<u128>;
-      readonly oldReserved: Compact<u128>;
-    } & Struct;
     readonly isForceTransfer: boolean;
     readonly asForceTransfer: {
       readonly source: MultiAddress;
@@ -899,17 +893,12 @@ declare module '@polkadot/types/lookup' {
     readonly asUpgradeAccounts: {
       readonly who: Vec<AccountId32>;
     } & Struct;
-    readonly isTransfer: boolean;
-    readonly asTransfer: {
-      readonly dest: MultiAddress;
-      readonly value: Compact<u128>;
-    } & Struct;
     readonly isForceSetBalance: boolean;
     readonly asForceSetBalance: {
       readonly who: MultiAddress;
       readonly newFree: Compact<u128>;
     } & Struct;
-    readonly type: 'TransferAllowDeath' | 'SetBalanceDeprecated' | 'ForceTransfer' | 'TransferKeepAlive' | 'TransferAll' | 'ForceUnreserve' | 'UpgradeAccounts' | 'Transfer' | 'ForceSetBalance';
+    readonly type: 'TransferAllowDeath' | 'ForceTransfer' | 'TransferKeepAlive' | 'TransferAll' | 'ForceUnreserve' | 'UpgradeAccounts' | 'ForceSetBalance';
   }
 
   /** @name PalletBalancesError (107) */


### PR DESCRIPTION
* Generate node-api for polkadot-v1.2.0: Calls to `transfer` converted to  `transferAllowDeath`.
* Adapt balance amounts checks - impacted by inflation.

logion-network/logion-internal#1069