### PR TITLE
Enable TC validation without LOC id.

### DIFF
--- a/packages/client-node/package.json
+++ b/packages/client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-node",
-  "version": "0.2.0",
+  "version": "0.2.1-1",
   "description": "logion SDK for Node.JS client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.35.0",
+  "version": "0.36.0-1",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.36.0-1",
+  "version": "0.36.0-2",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/license/CreativeCommons.ts
+++ b/packages/client/src/license/CreativeCommons.ts
@@ -43,6 +43,12 @@ export class CreativeCommons extends AbstractTermsAndConditionsElement<CreativeC
         return new CreativeCommons(licenseLocId, details as CreativeCommonsCode);
     }
 
+    static validateDetails(details: string) {
+        if (!values.has(details as CreativeCommonsCode)) {
+            throw new Error(`Invalid parameters: ${ details }. Valid values are: ${ (Array.from(values)) }.`)
+        }
+    }
+
     get details(): string {
         return this.parameters;
     }

--- a/packages/client/src/license/LogionClassification.ts
+++ b/packages/client/src/license/LogionClassification.ts
@@ -324,10 +324,10 @@ export class LogionClassification extends AbstractTermsAndConditionsElement<Logi
     }
 
     checkValidity() {
-        LogionClassification.staticCheckValidity(this.parameters);
+        LogionClassification.checkValidity(this.parameters);
     }
 
-    static staticCheckValidity(parameters: LogionLicenseParameters) {
+    static checkValidity(parameters: LogionLicenseParameters) {
         const { transferredRights } = parameters;
         const expirationSet: Condition = params => params.expiration !== undefined && params.expiration.length > 0;
         const regionalLimitSet: Condition = params => params.regionalLimit !== undefined && params.regionalLimit.length > 0;
@@ -369,7 +369,7 @@ export class LogionClassification extends AbstractTermsAndConditionsElement<Logi
 
     static validateDetails(details: string) {
         const parameters = JSON.parse(details);
-        this.staticCheckValidity(parameters);
+        this.checkValidity(parameters);
     }
 }
 


### PR DESCRIPTION
Make it possible to validate T&C details without providing a value for the related LOC ID.

logion-network/logion-internal#1088