### PR TITLE
Provide client for invited contributors.

### DIFF
--- a/packages/client-browser/package.json
+++ b/packages/client-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-browser",
-  "version": "0.3.1",
+  "version": "0.3.2-1",
   "description": "logion SDK for client applications running in a browser",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client-node/integration/InvitedContributors.ts
+++ b/packages/client-node/integration/InvitedContributors.ts
@@ -1,0 +1,126 @@
+import { Hash, Lgnt } from "@logion/node-api";
+import {
+    ClosedLoc,
+    HashOrContent,
+    AcceptedRequest,
+    PendingRequest, OpenLoc, MimeType, waitFor
+} from "@logion/client";
+import {
+    State,
+    initRequesterBalance,
+    TEST_LOGION_CLIENT_CONFIG,
+    INVITED_CONTRIBUTOR_ADDRESS
+} from "./Utils.js";
+import { NodeFile } from "../src/index.js";
+import { InvitedContributorLoc } from "@logion/client/dist/InvitedContributor.js";
+
+export async function invitedContributors(state: State) {
+    const { alice, aliceAccount, invitedContributorAccount, newAccount, signer } = state;
+
+    const invitedContributorClient = state.client.withCurrentAddress(invitedContributorAccount);
+
+    await initRequesterBalance(TEST_LOGION_CLIENT_CONFIG, signer, INVITED_CONTRIBUTOR_ADDRESS);
+    let invitedContributorLocsState = await invitedContributorClient.locsState();
+    const pendingRequest = await invitedContributorLocsState.requestIdentityLoc({
+        legalOfficerAddress: alice.address,
+        description: "This is an invited contributor Identity LOC",
+        userIdentity: {
+            email: "john.doe.trusted@invalid.domain",
+            firstName: "John",
+            lastName: "Trusted",
+            phoneNumber: "+1234",
+        },
+        userPostalAddress: {
+            line1: "Peace Street",
+            line2: "2nd floor",
+            postalCode: "10000",
+            city: "MyCity",
+            country: "Wonderland"
+        },
+        draft: false,
+    });
+    const invitedContributorIdentityLocId = pendingRequest.data().id;
+
+    const aliceClient = state.client.withCurrentAddress(aliceAccount);
+    let aliceLocs = await aliceClient.locsState({ spec: { ownerAddress: aliceAccount.address, locTypes: ["Identity"], statuses: ["REVIEW_PENDING"] } });
+    const alicePending = aliceLocs.findById(invitedContributorIdentityLocId) as PendingRequest;
+    const aliceAccepted = await alicePending.legalOfficer.accept();
+
+    const acceptedIdentityLoc = await pendingRequest.refresh() as AcceptedRequest;
+    await acceptedIdentityLoc.open({ signer, autoPublish: false });
+
+    let aliceOpen = await aliceAccepted.refresh() as OpenLoc;
+    aliceOpen = await waitFor<OpenLoc>({
+        producer: prev => prev ? prev.refresh() as Promise<OpenLoc> : aliceOpen.refresh() as Promise<OpenLoc>,
+        predicate: state => state.legalOfficer.canClose(false),
+    });
+    await aliceOpen.legalOfficer.close({ signer, autoAck: false }) as ClosedLoc;
+
+    const requesterClient = state.client.withCurrentAddress(newAccount);
+    let userLocsState = await requesterClient.locsState();
+    let pendingLocRequest = await userLocsState.requestCollectionLoc({
+        legalOfficerAddress: alice.address,
+        description: "Some LOC with invited contributor",
+        draft: false,
+        legalFee: Lgnt.zero(),
+        collectionItemFee: Lgnt.zero(),
+        tokensRecordFee: Lgnt.zero(),
+        valueFee: Lgnt.fromCanonical(100n),
+    }) as PendingRequest;
+    const collectionLocId = pendingLocRequest.data().id;
+
+    aliceLocs = await aliceClient.locsState({ spec: { ownerAddress: aliceAccount.address, locTypes: ["Collection"], statuses: ["REVIEW_PENDING"] } });
+    const alicePendingCollection = aliceLocs.findById(collectionLocId) as PendingRequest;
+    await alicePendingCollection.legalOfficer.accept();
+
+    let acceptedLoc = await pendingLocRequest.refresh() as AcceptedRequest;
+    let openLoc = await acceptedLoc.openCollection({
+        signer,
+        autoPublish: false,
+        collectionCanUpload: false,
+        collectionMaxSize: 100,
+    });
+
+    let locWithInvitedContributor = await openLoc.setInvitedContributor({
+        signer,
+        payload: {
+            invitedContributor: INVITED_CONTRIBUTOR_ADDRESS,
+            selected: true,
+        }
+    });
+
+    expect(locWithInvitedContributor.data().invitedContributors.length).toBe(1);
+    expect(locWithInvitedContributor.data().invitedContributors[0].address).toBe(INVITED_CONTRIBUTOR_ADDRESS);
+    expect(locWithInvitedContributor.data().invitedContributors[0].type).toBe("Polkadot");
+
+    const aliceOpenLoc = await alicePendingCollection.refresh() as OpenLoc;
+    await aliceOpenLoc.legalOfficer.close({ signer, autoAck: false });
+
+    // Contribute tokens records with dedicated API
+    const api = invitedContributorClient.invitedContributor;
+    let loc = await api.findContributedLocById({ locId: collectionLocId }) as InvitedContributorLoc;
+    expect(loc).toBeDefined();
+    const recordId = Hash.of("record-id");
+    const recordDescription = "Some tokens record";
+    await loc!.addTokensRecord({
+        payload: {
+            recordId,
+            description: recordDescription,
+            files: [
+                HashOrContent.fromContent(new NodeFile("integration/test.txt", "report.txt", MimeType.from("text/plain"))),
+            ],
+        },
+        signer: state.signer,
+    });
+
+    const publicApi = invitedContributorClient.public;
+    const records = await publicApi.getTokensRecords({
+        locId: collectionLocId,
+        jwtToken: invitedContributorClient.tokens.get()
+    })
+
+    expect(records.length).toBe(1);
+    expect(records[0].id).toEqual(recordId);
+    expect(records[0].description.validValue()).toBe(recordDescription);
+    expect(records[0].files.length).toBe(1);
+}

--- a/packages/client-node/integration/InvitedContributors.ts
+++ b/packages/client-node/integration/InvitedContributors.ts
@@ -98,7 +98,7 @@ export async function invitedContributors(state: State) {
 
     // Contribute tokens records with dedicated API
     const api = invitedContributorClient.invitedContributor;
-    let loc = await api.findContributedLocById({ locId: collectionLocId }) as InvitedContributorLoc;
+    let loc = await api.findLocById({ locId: collectionLocId }) as InvitedContributorLoc;
     expect(loc).toBeDefined();
     const recordId = Hash.of("record-id");
     const recordDescription = "Some tokens record";

--- a/packages/client-node/integration/Main.spec.ts
+++ b/packages/client-node/integration/Main.spec.ts
@@ -20,6 +20,7 @@ import { backendConfig } from "./LegalOfficer.js";
 import { voidTransactionLoc } from "./Void.js";
 import { votingProcess } from "./Vote.js";
 import { openIdentityLoc, openTransactionLoc, openCollectionLoc } from "./DirectLocOpen.js";
+import { invitedContributors } from "./InvitedContributors.js";
 
 describe("Logion SDK", () => {
 
@@ -47,7 +48,7 @@ describe("Logion SDK", () => {
         await transfers(state);
     });
 
-    it("refuses transfer with unsufficient funds", async () => {
+    it("refuses transfer with insufficient funds", async () => {
         await transferWithInsufficientFunds(state);
     });
 
@@ -108,6 +109,10 @@ describe("Logion SDK", () => {
 
     it("provides Tokens Records", async () => {
         await tokensRecords(state);
+    });
+
+    it("provides invited contributor", async () => {
+        await invitedContributors(state);
     });
 
     it("voids a Transaction LOC", async () => {

--- a/packages/client-node/integration/TokensRecord.ts
+++ b/packages/client-node/integration/TokensRecord.ts
@@ -52,11 +52,13 @@ export async function tokensRecords(state: State) {
     });
     expect(estimatedFees.tokensRecordFee).toEqual(tokensRecordFee);
     closedCollectionLoc = await closedCollectionLoc.addTokensRecord({
-        recordId,
-        description: recordDescription,
-        files: [
-            HashOrContent.fromContent(new NodeFile("integration/test.txt", "report.txt", MimeType.from("text/plain"))),
-        ],
+        payload: {
+            recordId,
+            description: recordDescription,
+            files: [
+                HashOrContent.fromContent(new NodeFile("integration/test.txt", "report.txt", MimeType.from("text/plain"))),
+            ],
+        },
         signer: state.signer,
     });
     await expectAsync(waitFor<BalanceState>({

--- a/packages/client-node/integration/Utils.ts
+++ b/packages/client-node/integration/Utils.ts
@@ -57,6 +57,9 @@ export const ISSUER_SECRET_SEED = "exit photo know trouble stay hollow gate rive
 export const ETHEREUM_ADDRESS = "0x2469a2fd33ad71a3525cc2047bdd4f3ca851e89f";
 export const ETHEREUM_SEED = "0x09dc05bbed08ff234919b84002a1eb6f856a6e949b017289fc7d457e1bb5e9d4";
 
+export const INVITED_CONTRIBUTOR_ADDRESS = "5F42HAi5kvD6Ao4Ze6UBiZDw7BA4zk62twNYRWAVDq3EhdWH";
+export const INVITED_CONTRIBUTOR_SECRET_SEED = "october minimum future canvas range cruise jealous web renew border hover name";
+
 export interface State {
     signer: FullSigner;
     client: LogionClient;
@@ -71,6 +74,7 @@ export interface State {
     charlieAccount: ValidAccountId,
     issuerAccount: ValidAccountId,
     ethereumAccount: ValidAccountId,
+    invitedContributorAccount: ValidAccountId,
 }
 
 export async function setupInitialState(config: LogionClientConfig = TEST_LOGION_CLIENT_CONFIG): Promise<State> {
@@ -83,6 +87,7 @@ export async function setupInitialState(config: LogionClientConfig = TEST_LOGION
         BOB_SECRET_SEED,
         CHARLIE_SECRET_SEED,
         ISSUER_SECRET_SEED,
+        INVITED_CONTRIBUTOR_SECRET_SEED,
     ]);
     const requesterAccount = anonymousClient.logionApi.queries.getValidAccountId(REQUESTER_ADDRESS, "Polkadot");
     const directRequesterAccount = anonymousClient.logionApi.queries.getValidAccountId(DIRECT_REQUESTER_ADDRESS, "Polkadot");
@@ -92,6 +97,7 @@ export async function setupInitialState(config: LogionClientConfig = TEST_LOGION
     const charlieAccount = anonymousClient.logionApi.queries.getValidAccountId(CHARLIE, "Polkadot");
     const issuerAccount = anonymousClient.logionApi.queries.getValidAccountId(ISSUER_ADDRESS, "Polkadot");
     const ethereumAccount = anonymousClient.logionApi.queries.getValidAccountId(ETHEREUM_ADDRESS, "Ethereum");
+    const invitedContributorAccount = anonymousClient.logionApi.queries.getValidAccountId(INVITED_CONTRIBUTOR_ADDRESS, "Polkadot");
     const client = await anonymousClient.authenticate([
         requesterAccount,
         directRequesterAccount,
@@ -101,6 +107,7 @@ export async function setupInitialState(config: LogionClientConfig = TEST_LOGION
         charlieAccount,
         issuerAccount,
         ethereumAccount,
+        invitedContributorAccount,
     ], signer);
     const legalOfficers = client.legalOfficers;
     const alice = requireDefined(legalOfficers.find(legalOfficer => legalOfficer.address === ALICE));
@@ -120,6 +127,7 @@ export async function setupInitialState(config: LogionClientConfig = TEST_LOGION
         charlieAccount,
         issuerAccount,
         ethereumAccount,
+        invitedContributorAccount,
     };
 }
 

--- a/packages/client-node/integration/VerifiedIssuer.ts
+++ b/packages/client-node/integration/VerifiedIssuer.ts
@@ -61,8 +61,8 @@ export async function verifiedIssuer(state: State) {
     const transactionLocId = pendingLocRequest.data().id;
 
     aliceLocs = await aliceClient.locsState({ spec: { ownerAddress: aliceAccount.address, locTypes: ["Transaction"], statuses: ["REVIEW_PENDING"] } });
-    const alicePendingTransation = aliceLocs.findById(transactionLocId) as PendingRequest;
-    const aliceAcceptedTransaction = await alicePendingTransation.legalOfficer.accept() as AcceptedRequest;
+    const alicePendingTransaction = aliceLocs.findById(transactionLocId) as PendingRequest;
+    const aliceAcceptedTransaction = await alicePendingTransaction.legalOfficer.accept() as AcceptedRequest;
 
     let acceptedLoc = await pendingLocRequest.refresh() as AcceptedRequest;
     let openLoc = await acceptedLoc.open({ signer, autoPublish: false });

--- a/packages/client-node/package.json
+++ b/packages/client-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-node",
-  "version": "0.3.1",
+  "version": "0.3.2-1",
   "description": "logion SDK for Node.JS client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client-react-native-fs/package.json
+++ b/packages/client-react-native-fs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-react-native-fs",
-  "version": "0.2.1",
+  "version": "0.2.2-1",
   "description": "logion SDK for client applications running in a React Native app using react-native-fs",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.37.0",
+  "version": "0.38.0-1",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/InvitedContributor.ts
+++ b/packages/client/src/InvitedContributor.ts
@@ -1,0 +1,79 @@
+import {
+    AuthenticatedLocClient,
+    AddTokensRecordParams,
+    FetchParameters,
+    BlockchainSubmission,
+    withLocId
+} from "./LocClient.js";
+import { PublicLoc } from "./Public.js";
+import { SharedState } from "./SharedClient.js";
+import { LogionClient } from "./LogionClient.js";
+import { DateTime } from "luxon";
+import { requireDefined } from "./assertions.js";
+
+export class InvitedContributorApi {
+
+    constructor(args: {
+        sharedState: SharedState,
+        logionClient: LogionClient,
+
+    }) {
+        this.sharedState = args.sharedState;
+        this.logionClient = args.logionClient;
+    }
+
+    private readonly sharedState: SharedState;
+    private readonly logionClient: LogionClient;
+
+    async findContributedLocById(params: FetchParameters): Promise<InvitedContributorLoc | undefined> {
+
+        if (!this.sharedState.currentAddress) {
+            throw new Error("Current address must be set");
+        }
+        if (!this.logionClient.isTokenValid(DateTime.now())) {
+            throw new Error("Client must be authenticated");
+        }
+        const loc = await this.logionClient.public.findLocById(params);
+        if (loc === undefined) {
+            return undefined;
+        }
+        const legalOfficer = this.sharedState.legalOfficers.find(lo => lo.address === loc.data.ownerAddress);
+        if (!legalOfficer) {
+            return undefined;
+        }
+        const authenticatedClient = new AuthenticatedLocClient({
+            ...this.sharedState,
+            axiosFactory: this.sharedState.axiosFactory,
+            nodeApi: this.sharedState.nodeApi,
+            currentAddress: this.sharedState.currentAddress,
+            legalOfficer,
+        });
+
+        return new InvitedContributorLoc({ loc, invitedContributorApi: this, authenticatedClient });
+    }
+}
+
+export class InvitedContributorLoc extends PublicLoc {
+
+    private invitedContributorApi: InvitedContributorApi;
+    private authenticatedClient: AuthenticatedLocClient;
+
+    constructor(args: {
+        loc: PublicLoc,
+        invitedContributorApi: InvitedContributorApi,
+        authenticatedClient: AuthenticatedLocClient
+    }) {
+        super({ data: args.loc.data, client: args.loc.client });
+        this.invitedContributorApi = args.invitedContributorApi;
+        this.authenticatedClient = args.authenticatedClient;
+    }
+
+    async addTokensRecord(parameters: BlockchainSubmission<AddTokensRecordParams>): Promise<InvitedContributorLoc> {
+        if(!await this.authenticatedClient.isInvitedContributorOf(super.data.id)) {
+            throw new Error("Current user is not allowed to add a tokens record");
+        }
+        await this.authenticatedClient.addTokensRecord(withLocId(super.data.id, parameters));
+        return requireDefined(await this.invitedContributorApi.findContributedLocById({ locId: super.data.id }))
+    }
+}
+

--- a/packages/client/src/InvitedContributor.ts
+++ b/packages/client/src/InvitedContributor.ts
@@ -25,7 +25,7 @@ export class InvitedContributorApi {
     private readonly sharedState: SharedState;
     private readonly logionClient: LogionClient;
 
-    async findContributedLocById(params: FetchParameters): Promise<InvitedContributorLoc | undefined> {
+    async findLocById(params: FetchParameters): Promise<InvitedContributorLoc | undefined> {
 
         if (!this.sharedState.currentAddress) {
             throw new Error("Current address must be set");
@@ -73,7 +73,7 @@ export class InvitedContributorLoc extends PublicLoc {
             throw new Error("Current user is not allowed to add a tokens record");
         }
         await this.authenticatedClient.addTokensRecord(withLocId(super.data.id, parameters));
-        return requireDefined(await this.invitedContributorApi.findContributedLocById({ locId: super.data.id }))
+        return requireDefined(await this.invitedContributorApi.findLocById({ locId: super.data.id }))
     }
 }
 

--- a/packages/client/src/LogionClient.ts
+++ b/packages/client/src/LogionClient.ts
@@ -19,6 +19,7 @@ import { NetworkState } from "./NetworkState.js";
 import { VoterApi } from "./Voter.js";
 import { SponsorshipState, SponsorshipApi } from "./Sponsorship.js";
 import { requireDefined } from "./assertions.js";
+import { InvitedContributorApi } from "./InvitedContributor.js";
 
 export class LogionClient {
 
@@ -53,6 +54,7 @@ export class LogionClient {
         this.sharedState = sharedState;
         this._public = new PublicApi({ sharedState });
         this._voter = new VoterApi({ sharedState, logionClient: this });
+        this._invitedContributor = new InvitedContributorApi({ sharedState, logionClient: this })
     }
 
     private sharedState: SharedState;
@@ -60,6 +62,8 @@ export class LogionClient {
     private _public: PublicApi;
 
     private _voter: VoterApi;
+
+    private readonly _invitedContributor: InvitedContributorApi;
 
     get config(): LogionClientConfig {
         return this.sharedState.config;
@@ -257,7 +261,7 @@ export class LogionClient {
 
     /**
      * Builds an axios instance enabling direct access to a legal officer's node REST API.
-     * 
+     *
      * @param legalOfficer The legal officer
      * @returns The axios instance
      * @deprecated use LegalOfficerClass.buildAxiosToNode() instead
@@ -348,6 +352,11 @@ export class LogionClient {
     get voter(): VoterApi {
         this.ensureConnected();
         return this._voter;
+    }
+
+    get invitedContributor(): InvitedContributorApi {
+        this.ensureConnected();
+        return this._invitedContributor;
     }
 
     async disconnect() {

--- a/packages/client/src/Public.ts
+++ b/packages/client/src/Public.ts
@@ -35,7 +35,7 @@ export class PublicApi {
         const { loc, client } = locAndClient;
 
         const locRequest = await client.getLocRequest(params);
-        const data = LocRequestState.buildLocData(this.sharedState.nodeApi, loc, locRequest, EMPTY_LOC_ISSUERS);
+        const data = LocRequestState.buildLocData(this.sharedState.nodeApi, loc, locRequest, EMPTY_LOC_ISSUERS, []);
         return new PublicLoc({
             data,
             client,
@@ -99,15 +99,19 @@ export class PublicLoc {
         client: PublicLocClient,
     }) {
         this._data = args.data;
-        this.client = args.client;
+        this._client = args.client;
     }
 
     private readonly _data: LocData;
 
-    private readonly client: PublicLocClient;
+    private readonly _client: PublicLocClient;
 
     get data(): LocData {
         return this._data;
+    }
+
+    get client(): PublicLocClient {
+        return this._client;
     }
 
     async checkHash(hash: Hash, itemId?: Hash): Promise<CheckHashResult> {
@@ -116,13 +120,13 @@ export class PublicLoc {
         let collectionItemFile = undefined;
         if(this._data.locType === "Collection") {
             collectionItem = await getCollectionItem({
-                locClient: this.client,
+                locClient: this._client,
                 locId: this._data.id,
                 itemId: hash,
             });
             if (itemId) {
                 const collectionItemToInspect = await getCollectionItem({
-                    locClient: this.client,
+                    locClient: this._client,
                     locId: this._data.id,
                     itemId,
                 });
@@ -146,7 +150,7 @@ export class PublicLoc {
 
     async checkCertifiedCopy(hash: Hash): Promise<CheckCertifiedCopyResult> {
         try {
-            const delivery = await this.client.checkDelivery({
+            const delivery = await this._client.checkDelivery({
                 locId: this._data.id,
                 hash,
             });

--- a/packages/client/src/Voter.ts
+++ b/packages/client/src/Voter.ts
@@ -37,7 +37,7 @@ export class VoterApi {
             client,
             locsState,
         }
-        return new ReadOnlyLocState(locSharedState, locRequest, loc, EMPTY_LOC_ISSUERS);
+        return new ReadOnlyLocState(locSharedState, locRequest, loc, EMPTY_LOC_ISSUERS, []);
     }
 
     private async getLocAndClient(locId: UUID): Promise<{ loc: LegalOfficerCase, locRequest: LocRequest, client: AuthenticatedLocClient } | undefined> {

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -52,7 +52,7 @@ import {
     buildValidPolkadotAccountId,
     ItIsUuid,
     mockCodecWithToString,
-    MOCK_FILE
+    MOCK_FILE, mockOption, mockEmptyOption
 } from "./Utils.js";
 import { TestConfigFactory } from "./TestConfigFactory.js";
 import {
@@ -512,9 +512,11 @@ describe("ClosedCollectionLoc", () => {
         signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER.address))).returnsAsync(SUCCESSFUL_SUBMISSION);
 
         await closedLoc.addTokensRecord({
-            recordId: RECORD_ID,
-            description: RECORD_DESCRIPTION,
-            files: RECORD_FILES,
+            payload: {
+                recordId: RECORD_ID,
+                description: RECORD_DESCRIPTION,
+                files: RECORD_FILES,
+            },
             signer: signer.object(),
         });
 
@@ -1078,6 +1080,9 @@ async function buildSharedState(isVerifiedIssuer: boolean = false): Promise<Shar
                 ITEM_DESCRIPTION,
                 It.IsAny(),
             )).returns(addTokensRecordExtrinsic.object());
+
+            nodeApiMock.setup(instance => instance.polkadot.query.logionLoc.invitedContributorsByLocMap.entries(It.IsAny())).returns(Promise.resolve([]))
+            nodeApiMock.setup(instance => instance.polkadot.query.logionLoc.invitedContributorsByLocMap(It.IsAny(), It.IsAny())).returns(Promise.resolve(mockEmptyOption()))
 
             const closeExtrinsic = new Mock<SubmittableExtrinsic>();
             nodeApiMock.setup(instance => instance.polkadot.tx.logionLoc.close(It.IsAny(), It.IsAny(), It.IsAny())).returns(closeExtrinsic.object());

--- a/packages/crossmint/package.json
+++ b/packages/crossmint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/crossmint",
-  "version": "0.1.30",
+  "version": "0.1.31-1",
   "description": "logion SDK for Crossmint",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/extension",
-  "version": "0.7.4",
+  "version": "0.7.5-1",
   "description": "logion SDK for Polkadot JS extension",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/multiversx/package.json
+++ b/packages/multiversx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/multiversx",
-  "version": "0.1.11",
+  "version": "0.1.12-1",
   "description": "logion SDK for MultiversX",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/node-api/integration/InvitedContributors.ts
+++ b/packages/node-api/integration/InvitedContributors.ts
@@ -24,6 +24,9 @@ export async function invitedContributors() {
             false,
         ),
     );
+
+    expect(await api.queries.isInvitedContributorOf(INVITED_CONTRIBUTOR, collectionLocId)).toBeFalse();
+
     await signAndSendBatch(requester, [
         api.polkadot.tx.logionLoc.createCollectionLoc(
             collectionLocId.toDecimalString(),
@@ -43,6 +46,9 @@ export async function invitedContributors() {
             true,
         ),
     ]);
+
+    expect(await api.queries.isInvitedContributorOf(INVITED_CONTRIBUTOR, collectionLocId)).toBeTrue();
+
     await signAndSend(alice,
         api.polkadot.tx.logionLoc.close(
             collectionLocId.toDecimalString(),

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.27.0",
+  "version": "0.28.0-2",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/Queries.ts
+++ b/packages/node-api/src/Queries.ts
@@ -34,7 +34,7 @@ export interface CoinBalance {
 export const ARTIFICIAL_MAX_BALANCE = Currency.toPrefixedNumberAmount(100n);
 
 export class Queries {
-    
+
     constructor(
         api: ApiPromise,
         adapters: Adapters,
@@ -71,12 +71,12 @@ export class Queries {
     async getCoinBalances(accountId: string): Promise<CoinBalance[]> {
         const accountInfo = await this.api.query.system.account(accountId);
         const data = this.adapters.fromFrameSystemAccountInfo(accountInfo);
-    
+
         const logAvailable = Currency.toPrefixedNumberAmount(BigInt(data.available)).optimizeScale(3);
         const logReserved = Currency.toPrefixedNumberAmount(BigInt(data.reserved)).optimizeScale(3);
         const logTotal = Currency.toPrefixedNumberAmount(BigInt(data.total)).optimizeScale(3);
         const logLevel = logTotal.scientificNumber.divideBy(ARTIFICIAL_MAX_BALANCE.convertTo(logTotal.prefix).scientificNumber).toNumber();
-    
+
         return [
             Queries.buildCoinBalance({
                 coinId: 'lgnt',
@@ -273,5 +273,12 @@ export class Queries {
 
     getDefaultRegion(): Region {
         return this.adapters.fromLogionNodeRuntimeRegion(this.adapters.getDefaultLogionNodeRuntimeRegion());
+    }
+
+    async isInvitedContributorOf(address: string, locId: UUID): Promise<boolean> {
+        return this.isValidAccountId(address, "Polkadot") && (await this.api.query.logionLoc.invitedContributorsByLocMap(
+            locId.toDecimalString(),
+            address,
+        )).isSome
     }
 }


### PR DESCRIPTION
* Introduce new `InvitedContributorApi` to allow the invited contributor to add tokens records.
* Use new `BlockchainSubmission` for tokens records addition.
* Allow requester to add/remove an invited contributor to an open or closed collection.
* Expose invited contributors.

Companion of https://github.com/logion-network/logion-backend-ts/pull/287 (required for integration tests)

logion-network/logion-internal#1119

