### PR TITLE
Review-less protection activation

### DIFF
--- a/packages/client-node/integration/Main.spec.ts
+++ b/packages/client-node/integration/Main.spec.ts
@@ -1,5 +1,5 @@
 import { setupInitialState, State, tearDown } from "./Utils.js";
-import { enablesProtection, requestsProtectionAndCancel, requestValidIdentity } from "./Protection.js";
+import { enablesProtection, requestValidIdentity } from "./Protection.js";
 import { transferAndCannotPayFees, transfers, transferWithInsufficientFunds } from "./Balance.js";
 import { providesVault } from "./Vault.js";
 import { recoverLostAccount, recoverLostVault, requestRecoveryAndCancel, requestRecoveryWithResubmit } from "./Recovery.js";
@@ -7,7 +7,6 @@ import {
     requestTransactionLoc,
     collectionLoc,
     collectionLocWithUpload,
-    identityLoc,
     otherIdentityLoc,
     logionIdentityLoc,
     transactionLocWithCustomLegalFee,
@@ -54,7 +53,6 @@ describe("Logion SDK", () => {
 
     it("enables protection", async () => {
         const identityLocs = await requestValidIdentity(state, state.requesterAccount);
-        await requestsProtectionAndCancel(state, identityLocs);
         await enablesProtection(state, identityLocs);
     });
 

--- a/packages/client-node/integration/Vault.ts
+++ b/packages/client-node/integration/Vault.ts
@@ -51,7 +51,7 @@ export async function aliceAcceptsTransfer(state: State, request: VaultTransferR
     const amount = Lgnt.fromCanonical(BigInt(request!.amount));
     const vault = api.vault(
         requesterAccount.address,
-        activeProtection.protectionParameters.states.map(state => state.legalOfficer.address)
+        activeProtection.protectionParameters.legalOfficers.map(legalOfficer => legalOfficer.address),
     );
     const submittable = await vault.tx.approveVaultTransfer({
         signerId,

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.39.0-5",
+  "version": "0.39.0-6",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/VaultClient.ts
+++ b/packages/client/src/VaultClient.ts
@@ -4,6 +4,7 @@ import { aggregateArrays, MultiSourceHttpClient, initMultiSourceHttpClientState 
 import { NetworkState } from "./NetworkState.js";
 import { LegalOfficerEndpoint } from "./SharedClient.js";
 import { LegalOfficer, PostalAddress, UserIdentity } from "./Types.js";
+import { newBackendError } from "./Error.js";
 
 export type VaultTransferRequestStatus = "ACCEPTED" | "PENDING" | "REJECTED" | "CANCELLED" | "REJECTED_CANCELLED";
 
@@ -137,12 +138,16 @@ export class VaultClient {
     }
 
     private async getVaultTransferRequests(axios: AxiosInstance, legalOfficerAddress: string, fetch: FetchVaultTransferRequest): Promise<VaultTransferRequest[]> {
-        const requests = (await axios.put("/api/vault-transfer-request", fetch)
-            .then(response => response.data.requests)) as VaultTransferRequest[];
-        return requests.map(request => ({
-            ...request,
-            legalOfficerAddress,
-        }));
+        try {
+            const requests = (await axios.put("/api/vault-transfer-request", fetch)
+                .then(response => response.data.requests)) as VaultTransferRequest[];
+            return requests.map(request => ({
+                ...request,
+                legalOfficerAddress,
+            }));
+        } catch(e) {
+            throw newBackendError(e);
+        }
     }
 
     private filterByStatuses(requests: VaultTransferRequest[], statuses: VaultTransferRequestStatus[]): VaultTransferRequest[] {
@@ -154,11 +159,15 @@ export class VaultClient {
         params: CreateVaultTransferRequest,
     ): Promise<VaultTransferRequest> {
         const axios = this.axiosFactory.buildAxiosInstance(legalOfficer.node, this.token);
-        const response = await axios.post('/api/vault-transfer-request', params);
-        return {
-            ...response.data,
-            legalOfficerAddress: legalOfficer.address,
-        };
+        try {
+            const response = await axios.post('/api/vault-transfer-request', params);
+            return {
+                ...response.data,
+                legalOfficerAddress: legalOfficer.address,
+            };
+        } catch(e) {
+            throw newBackendError(e);
+        }
     }
 
     async cancelVaultTransferRequest(
@@ -166,7 +175,11 @@ export class VaultClient {
         request: VaultTransferRequest,
     ): Promise<void> {
         const axios = this.axiosFactory.buildAxiosInstance(legalOfficer.node, this.token);
-        return await axios.post(`/api/vault-transfer-request/${request.id}/cancel`);
+        try {
+            return await axios.post(`/api/vault-transfer-request/${request.id}/cancel`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
     }
 
     async acceptVaultTransferRequest(
@@ -174,7 +187,11 @@ export class VaultClient {
         request: VaultTransferRequest,
     ): Promise<void> {
         const axios = this.axiosFactory.buildAxiosInstance(legalOfficer.node, this.token);
-        return await axios.post(`/api/vault-transfer-request/${request.id}/accept`);
+        try {
+            return await axios.post(`/api/vault-transfer-request/${request.id}/accept`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
     }
 
     async rejectVaultTransferRequest(
@@ -183,7 +200,11 @@ export class VaultClient {
         rejectReason: string
     ): Promise<void> {
         const axios = this.axiosFactory.buildAxiosInstance(legalOfficer.node, this.token);
-        return await axios.post(`/api/vault-transfer-request/${request.id}/reject`, { rejectReason });
+        try {
+            return await axios.post(`/api/vault-transfer-request/${request.id}/reject`, { rejectReason });
+        } catch(e) {
+            throw newBackendError(e);
+        }
     }
 
     async resubmitVaultTransferRequest(
@@ -191,7 +212,11 @@ export class VaultClient {
         request: VaultTransferRequest,
     ): Promise<void> {
         const axios = this.axiosFactory.buildAxiosInstance(legalOfficer.node, this.token);
-        return await axios.post(`/api/vault-transfer-request/${request.id}/resubmit`);
+        try {
+            return await axios.post(`/api/vault-transfer-request/${request.id}/resubmit`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
     }
 }
 


### PR DESCRIPTION
* Protection can now directly be activated from `NoProtection` state without any review by a LLO.
* The review logic remains for recovery requests.
* Relies on https://github.com/logion-network/logion-backend-ts/pull/291

logion-network/logion-internal#1123