### PR TITLE
Optimize workload fetching

### DIFF
--- a/packages/client-browser/package.json
+++ b/packages/client-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client-browser",
-  "version": "0.3.3",
+  "version": "0.3.4-1",
   "description": "logion SDK for client applications running in a browser",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client-node/integration/LegalOfficer.ts
+++ b/packages/client-node/integration/LegalOfficer.ts
@@ -11,12 +11,13 @@ export async function backendConfig(state: State) {
     expect(config.features.vote).toBe(false);
 }
 
-export async function workload(state: State) {
+export async function workload(state: State, ...legalOfficerAddresses: string[]) {
     const { client, requesterAccount } = state;
 
     const authenticatedClient = client.withCurrentAddress(requesterAccount);
-    const alice = authenticatedClient.getLegalOfficer(ALICE);
-    const workload = await alice.getWorkload();
-
-    expect(workload).toBe(0);
+    for (const address of legalOfficerAddresses) {
+        const legalOfficer = authenticatedClient.getLegalOfficer(address);
+        const workload = await legalOfficer.getWorkload();
+        expect(workload).toBe(0);
+    }
 }

--- a/packages/client-node/integration/Main.spec.ts
+++ b/packages/client-node/integration/Main.spec.ts
@@ -1,4 +1,4 @@
-import { setupInitialState, State, tearDown } from "./Utils.js";
+import { setupInitialState, State, tearDown, ALICE, BOB } from "./Utils.js";
 import { enablesProtection, requestValidIdentity } from "./Protection.js";
 import { transferAndCannotPayFees, transfers, transferWithInsufficientFunds } from "./Balance.js";
 import { providesVault } from "./Vault.js";
@@ -36,7 +36,7 @@ describe("Logion SDK", () => {
     });
 
     it("fetches workload", async () => {
-        await workload(state);
+        await workload(state, ALICE, BOB, ALICE);
     });
 
     it("estimates fees", async () => {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.40.0-1",
+  "version": "0.40.0-3",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",


### PR DESCRIPTION
* Workload is now fetched once per backend, for all legal officers hosted on this backend.
* The result is cached for a configurable amount of time (currently set to 10 sec - to be discussed).

Companion of https://github.com/logion-network/logion-backend-ts/pull/294

logion-network/logion-internal#1136