### PR TITLE
Tokens records batch

### DIFF
--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -2350,6 +2350,29 @@ export class ClosedCollectionLoc extends ClosedOrVoidCollectionLoc {
         return this.getCurrentStateOrThrow() as ClosedCollectionLoc;
     }
 
+    async addTokensRecords(parameters: BlockchainBatchSubmission<AddTokensRecordParams>): Promise<ClosedCollectionLoc> {
+        const { signer, callback } = parameters;
+        const client = this.locSharedState.client;
+        const payload = parameters.payload.map(payload => {
+            if(payload.files.length === 0) {
+                throw new Error("Cannot add a tokens record without files");
+            }
+            return {
+                ...payload,
+                locId: this.locId,
+            };
+        });
+        if(!await client.canAddRecord(this.request)) {
+            throw new Error("Current user is not allowed to add tokens records");
+        }
+        await client.addTokensRecords({
+            signer,
+            callback,
+            payload,
+        })
+        return this.getCurrentStateOrThrow() as ClosedCollectionLoc;
+    }
+
     async requestSof(params: CreateSofRequestParams): Promise<PendingRequest> {
         return requestSof(this.locSharedState, this.locId, params.itemId);
     }

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -538,6 +538,31 @@ describe("ClosedCollectionLoc", () => {
         )),Times.Once());
     });
 
+    it("adds tokens records", async () => {
+        const closedLoc = await getClosedCollectionLoc();
+        const signer = new Mock<Signer>();
+        signer.setup(instance => instance.signAndSend(It.Is<SignParameters>(params => params.signerId === REQUESTER.address))).returnsAsync(SUCCESSFUL_SUBMISSION);
+
+        await closedLoc.addTokensRecords({
+            payload: [
+                {
+                    recordId: RECORD_ID,
+                    description: RECORD_DESCRIPTION,
+                    files: RECORD_FILES,
+                },
+                {
+                    recordId: OTHER_RECORD_ID,
+                    description: OTHER_RECORD_DESCRIPTION,
+                    files: OTHER_RECORD_FILES,
+                }
+            ],
+            signer: signer.object(),
+        });
+
+        signer.verify(instance => instance.signAndSend(It.IsAny()), Times.Once());
+        nodeApiMock.verify(instance => instance.polkadot.tx.logionLoc.addTokensRecord(It.IsAny(), It.IsAny(), It.IsAny(), It.IsAny()), Times.Exactly(2));
+    });
+
     it("can be voided", async () => {
         const openLoc = await getClosedCollectionLoc();
         const signer = new Mock<Signer>();
@@ -872,6 +897,10 @@ const CREATIVE_COMMONS: CreativeCommonsCode = "BY-SA";
 const RECORD_ID = Hash.fromHex("0x186bf67f32bb45187a1c50286dbd9adf8751874831aeba2a66760a74a9c898cc");
 const RECORD_DESCRIPTION = "Some record description";
 const RECORD_FILES: HashOrContent[] = [ HashOrContent.fromContent(MOCK_FILE) ];
+
+const OTHER_RECORD_ID = Hash.fromHex("0x0c274fac19724c028d4a20a86a68930df23df80f9e8171b5b8bf733cc605c766");
+const OTHER_RECORD_DESCRIPTION = "Some other record description";
+const OTHER_RECORD_FILES: HashOrContent[] = [ HashOrContent.fromContent(MOCK_FILE) ];
 
 let aliceAxiosMock: Mock<AxiosInstance>;
 let bobAxiosMock: Mock<AxiosInstance>;

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.28.2",
+  "version": "0.28.3-1",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
* Enables submission of tokens records by batch.
* Bump node-api in order to publish changes submitted by Etienne of EY/Fabernovel.