### PR TITLE
Encapsulate and move collection params to request.

### DIFF
--- a/packages/client-node/integration/DirectLocOpen.ts
+++ b/packages/client-node/integration/DirectLocOpen.ts
@@ -109,8 +109,10 @@ export async function openCollectionLoc(state: State, linkedLoc1: UUID, linkedLo
         files: items.files,
         metadata: items.metadata,
         links: items.links,
-        collectionCanUpload: false,
-        collectionMaxSize: 200,
+        collectionParams: {
+            canUpload: false,
+            maxSize: 200,
+        },
         valueFee: Lgnt.fromCanonical(13000n),
         collectionItemFee: Lgnt.fromCanonical(7000n),
         tokensRecordFee: Lgnt.fromCanonical(6000n),
@@ -120,9 +122,9 @@ export async function openCollectionLoc(state: State, linkedLoc1: UUID, linkedLo
 }
 
 function checkCollectionData(data: LocData, items: ItemsParams) {
-    expect(data.collectionCanUpload).toBeFalse();
-    expect(data.collectionMaxSize).toEqual(200);
-    expect(data.collectionLastBlockSubmission).toBeUndefined();
+    expect(data.collectionParams?.canUpload).toBeFalse();
+    expect(data.collectionParams?.maxSize).toEqual(200);
+    expect(data.collectionParams?.lastBlockSubmission).toBeUndefined();
     expect(data.fees.valueFee?.canonical).toEqual(13000n);
     expect(data.fees.collectionItemFee?.canonical).toEqual(7000n);
     expect(data.fees.tokensRecordFee?.canonical).toEqual(6000n);

--- a/packages/client-node/integration/InvitedContributors.ts
+++ b/packages/client-node/integration/InvitedContributors.ts
@@ -69,6 +69,10 @@ export async function invitedContributors(state: State) {
         collectionItemFee: Lgnt.zero(),
         tokensRecordFee: Lgnt.zero(),
         valueFee: Lgnt.fromCanonical(100n),
+        collectionParams: {
+            canUpload: false,
+            maxSize: 100,
+        }
     }) as PendingRequest;
     const collectionLocId = pendingLocRequest.data().id;
 
@@ -77,11 +81,9 @@ export async function invitedContributors(state: State) {
     await alicePendingCollection.legalOfficer.accept();
 
     let acceptedLoc = await pendingLocRequest.refresh() as AcceptedRequest;
-    let openLoc = await acceptedLoc.openCollection({
+    let openLoc = await acceptedLoc.open({
         signer,
         autoPublish: false,
-        collectionCanUpload: false,
-        collectionMaxSize: 100,
     });
 
     let locWithInvitedContributor = await openLoc.setInvitedContributor({

--- a/packages/client-node/integration/Loc.ts
+++ b/packages/client-node/integration/Loc.ts
@@ -334,6 +334,11 @@ export async function collectionLoc(state: State) {
         collectionItemFee,
         tokensRecordFee: Lgnt.fromCanonical(50n),
         legalFee: Lgnt.zero(),
+        collectionParams: {
+            lastBlockSubmission: 100000n,
+            maxSize: 9999,
+            canUpload: true,
+        }
     });
     expect(pendingRequest.data().fees.valueFee?.canonical).toBe(100n);
     expect(pendingRequest.data().fees.collectionItemFee?.canonical).toBe(50n);
@@ -353,9 +358,7 @@ export async function collectionLoc(state: State) {
     locsState = acceptedLoc.locsState();
     expect(locsState.acceptedRequests["Collection"][0].data().status).toBe("REVIEW_ACCEPTED");
 
-    let openLoc = await acceptedLoc.openCollection({
-        collectionMaxSize: 100,
-        collectionCanUpload: true,
+    let openLoc = await acceptedLoc.open({
         autoPublish: false,
         signer,
     });
@@ -471,15 +474,17 @@ export async function collectionLocWithUpload(state: State) {
         valueFee: Lgnt.fromCanonical(100n),
         collectionItemFee: Lgnt.fromCanonical(50n),
         tokensRecordFee: Lgnt.fromCanonical(50n),
+        collectionParams: {
+            maxSize: 100,
+            canUpload: true,
+        }
     });
 
     let alicePendingRequest = await findWithLegalOfficerClient(aliceClient, pendingRequest) as PendingRequest;
     let aliceAcceptedLoc = await alicePendingRequest.legalOfficer.accept();
 
     let acceptedLoc = await pendingRequest.refresh() as AcceptedRequest;
-    let openLoc = await acceptedLoc.openCollection({
-        collectionMaxSize: 100,
-        collectionCanUpload: true,
+    let openLoc = await acceptedLoc.open({
         autoPublish: false,
         signer,
     });

--- a/packages/client-node/integration/TokensRecord.ts
+++ b/packages/client-node/integration/TokensRecord.ts
@@ -22,6 +22,10 @@ export async function tokensRecords(state: State) {
         valueFee: Lgnt.fromCanonical(100n),
         collectionItemFee: Lgnt.fromCanonical(50n),
         tokensRecordFee,
+        collectionParams: {
+            maxSize: 100,
+            canUpload: true,
+        }
     });
     const collectionLocId = collectionLoc.locId;
     const aliceClient = client.withCurrentAddress(aliceAccount);
@@ -30,7 +34,7 @@ export async function tokensRecords(state: State) {
     let aliceAcceptedLoc = await alicePendingRequest.legalOfficer.accept();
 
     let acceptedLoc = await collectionLoc.refresh() as AcceptedRequest;
-    await acceptedLoc.openCollection({ collectionMaxSize: 100, collectionCanUpload: true, signer, autoPublish: false });
+    await acceptedLoc.open({ signer, autoPublish: false });
     let aliceOpenLoc = await aliceAcceptedLoc.refresh() as OpenLoc;
 
     aliceOpenLoc = await aliceOpenLoc.legalOfficer.selectIssuer({ issuer: ISSUER_ADDRESS, signer });

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.41.1-1",
+  "version": "0.41.1-2",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -54,7 +54,7 @@ import {
     AutoPublish,
     SetInvitedContributorSelectionParams,
     withLocId,
-    addToPayload,
+    withAdditional,
     toBlockchainSubmission,
     CollectionParams,
     BackendCollectionParams,
@@ -445,17 +445,17 @@ export class LocsState extends State {
         const locSharedState: LocSharedState = { ...this.sharedState, legalOfficer, client, locsState: this };
         if (payload.locType === "Identity") {
             await client.openIdentityLoc(
-                addToPayload({ locId, autoPublish: false }, params),
+                withAdditional({ locId, autoPublish: false }, params),
                 false
             );
         } else if (payload.locType === "Transaction") {
             await client.openTransactionLoc(
-                addToPayload({ locId, autoPublish: false }, params),
+                withAdditional({ locId, autoPublish: false }, params),
                 false
             );
         } else if (payload.locType === "Collection") {
             await client.openCollectionLoc(
-                addToPayload({
+                withAdditional({
                         collectionParams: requireDefined(collectionParams),
                         valueFee: requireDefined(payload.valueFee),
                         collectionItemFee: requireDefined(payload.collectionItemFee),

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -44,7 +44,7 @@ import {
     EstimateFeesPublishFileParams,
     EstimateFeesPublishMetadataParams,
     EstimateFeesPublishLinkParams,
-    EstimateFeesOpenCollectionLocParams,
+    OpenCollectionLocParams,
     OpenPolkadotLocParams,
     RefLinkParams,
     AckLinkParams,
@@ -52,9 +52,12 @@ import {
     ItemsParams,
     ItemLifecycle as BackendItemLifecycle,
     AutoPublish,
-    CollectionLimits,
     SetInvitedContributorSelectionParams,
     withLocId,
+    addToPayload,
+    toBlockchainSubmission,
+    CollectionParams,
+    BackendCollectionParams,
 } from "./LocClient.js";
 import { BlockchainSubmission, BlockchainSubmissionParams, BlockchainBatchSubmission } from "./Signer.js";
 import { SharedState, getLegalOfficer } from "./SharedClient.js";
@@ -88,9 +91,7 @@ export interface LocData extends LocVerifiedIssuers {
     identityLocId?: UUID;
     userIdentity?: UserIdentity;
     userPostalAddress?: PostalAddress;
-    collectionLastBlockSubmission?: bigint;
-    collectionMaxSize?: number;
-    collectionCanUpload?: boolean;
+    collectionParams?: CollectionParams;
     files: MergedFile[];
     metadata: MergedMetadataItem[];
     links: MergedLink[];
@@ -304,6 +305,10 @@ export class LocsState extends State {
     }
 
     async requestCollectionLoc(params: CreateCollectionLocRequestParams): Promise<DraftRequest | PendingRequest> {
+        const { lastBlockSubmission, maxSize } = params.collectionParams;
+        if (lastBlockSubmission === undefined) {
+            requireDefined(maxSize, () => Error("Missing Collection upper bound."));
+        }
         return this.requestLoc({
             ...params,
             locType: "Collection"
@@ -346,7 +351,8 @@ export class LocsState extends State {
                 valueFee: params.valueFee?.canonical.toString(),
                 collectionItemFee: params.collectionItemFee?.canonical.toString(),
                 tokensRecordFee: params.tokensRecordFee?.canonical.toString(),
-            }
+            },
+            collectionParams: this.toBackendCollectionParams(params.collectionParams),
         });
         const locSharedState: LocSharedState = { ...this.sharedState, legalOfficer, client, locsState: this };
         if(draft) {
@@ -356,18 +362,32 @@ export class LocsState extends State {
         }
     }
 
+    private toBackendCollectionParams(collectionParams: CollectionParams | undefined): BackendCollectionParams | undefined {
+        return collectionParams ?
+            {
+                lastBlockSubmission: collectionParams.lastBlockSubmission?.toString(),
+                maxSize: collectionParams.maxSize?.toString(),
+                canUpload: collectionParams.canUpload,
+            } :
+            undefined
+    }
+
     async openTransactionLoc(params: CreateLocParams & ItemsParams & BlockchainSubmissionParams): Promise<OpenLoc> {
-        return this.openLoc({
+        return this.openLoc(toBlockchainSubmission({
             ...params,
             locType: "Transaction"
-        });
+        }));
     }
 
     async openCollectionLoc(params: CreateCollectionLocParams & ItemsParams & BlockchainSubmissionParams): Promise<OpenLoc> {
-        return this.openLoc({
+        const { lastBlockSubmission, maxSize } = params.collectionParams;
+        if (lastBlockSubmission === undefined) {
+            requireDefined(maxSize, () => Error("Missing Collection upper bound."));
+        }
+        return this.openLoc(toBlockchainSubmission({
             ...params,
             locType: "Collection"
-        });
+        }));
     }
 
     async openIdentityLoc(params: CreateIdentityLocParams & ItemsParams & BlockchainSubmissionParams): Promise<OpenLoc> {
@@ -378,14 +398,15 @@ export class LocsState extends State {
         if (userPostalAddress === undefined) {
             throw new Error("User Postal Address is mandatory for an Identity LOC")
         }
-        return this.openLoc({
+        return this.openLoc(toBlockchainSubmission({
             ...params,
             locType: "Identity"
-        });
+        }));
     }
 
-    private async openLoc(params: CreateAnyLocParams & ItemsParams & BlockchainSubmissionParams): Promise<OpenLoc> {
-        const { legalOfficerAddress, locType, description, userIdentity, userPostalAddress, company, template, metadata, links } = params;
+    private async openLoc(params: BlockchainSubmission<CreateAnyLocParams & ItemsParams>): Promise<OpenLoc> {
+        const { payload } = params;
+        const { legalOfficerAddress, locType, description, userIdentity, userPostalAddress, company, template, metadata, links, collectionParams } = payload;
         const legalOfficer = getLegalOfficer(this.sharedState, legalOfficerAddress)
         if (this.sharedState.currentAddress?.type !== "Polkadot") {
             throw Error("Direct LOC opening must be done by Polkadot account");
@@ -400,20 +421,21 @@ export class LocsState extends State {
             company,
             template,
             fees: {
-                legalFee: params.legalFee?.canonical.toString(),
-                valueFee: params.valueFee?.canonical.toString(),
-                collectionItemFee: params.collectionItemFee?.canonical.toString(),
-                tokensRecordFee: params.tokensRecordFee?.canonical.toString(),
+                legalFee: payload.legalFee?.canonical.toString(),
+                valueFee: payload.valueFee?.canonical.toString(),
+                collectionItemFee: payload.collectionItemFee?.canonical.toString(),
+                tokensRecordFee: payload.tokensRecordFee?.canonical.toString(),
             },
             metadata,
             links: links.map(link => ({
                 target: link.target.toString(),
                 nature: link.nature
-            }))
+            })),
+            collectionParams: this.toBackendCollectionParams(collectionParams),
         });
 
         const locId = new UUID(request.id);
-        for (const file of params.files) {
+        for (const file of payload.files) {
             await client.addFile({
                 ...file,
                 locId,
@@ -421,29 +443,30 @@ export class LocsState extends State {
             })
         }
         const locSharedState: LocSharedState = { ...this.sharedState, legalOfficer, client, locsState: this };
-        if (params.locType === "Identity") {
-            await client.openIdentityLoc({
-                ...params,
-                locId,
-                autoPublish: false,
-            }, false);
-        } else if (params.locType === "Transaction") {
-            await client.openTransactionLoc({
-                ...params,
-                locId,
-                autoPublish: false,
-            }, false);
-        } else if (params.locType === "Collection") {
-            await client.openCollectionLoc({
-                collectionCanUpload: requireDefined(params.collectionCanUpload),
-                collectionLastBlockSubmission: params.collectionLastBlockSubmission,
-                collectionMaxSize: params.collectionMaxSize,
-                valueFee: requireDefined(params.valueFee),
-                collectionItemFee: requireDefined(params.collectionItemFee),
-                tokensRecordFee: requireDefined(params.tokensRecordFee),
-                ...params, locId,
-                autoPublish: false,
-            }, false);
+        if (payload.locType === "Identity") {
+            await client.openIdentityLoc(
+                addToPayload({ locId, autoPublish: false }, params),
+                false
+            );
+        } else if (payload.locType === "Transaction") {
+            await client.openTransactionLoc(
+                addToPayload({ locId, autoPublish: false }, params),
+                false
+            );
+        } else if (payload.locType === "Collection") {
+            await client.openCollectionLoc(
+                addToPayload({
+                        collectionParams: requireDefined(collectionParams),
+                        valueFee: requireDefined(payload.valueFee),
+                        collectionItemFee: requireDefined(payload.collectionItemFee),
+                        tokensRecordFee: requireDefined(payload.tokensRecordFee),
+                        locId,
+                        autoPublish: false
+                    },
+                    params
+                ),
+                false
+            );
         }
         const loc = await client.getLoc({ locId });
         return (await new OpenLoc(locSharedState, request, loc, EMPTY_LOC_ISSUERS, []).refresh()) as OpenLoc;
@@ -695,16 +718,17 @@ export interface CreateIdentityLocRequestParams extends CreateLocRequestParams, 
 export interface CreateIdentityLocParams extends CreateLocParams, HasIdentity {
 }
 
-export interface CreateCollectionLocParams extends CreateLocParams, EstimateFeesOpenCollectionLocParams {
+export interface CreateCollectionLocParams extends CreateLocParams, OpenCollectionLocParams {
 }
 
 export interface CreateCollectionLocRequestParams extends CreateLocRequestParams {
     valueFee: Lgnt;
     collectionItemFee: Lgnt;
     tokensRecordFee: Lgnt;
+    collectionParams: CollectionParams;
 }
 
-interface CreateAnyLocParams extends CreateLocParams, Partial<HasIdentity>, Partial<EstimateFeesOpenCollectionLocParams> {
+interface CreateAnyLocParams extends CreateLocParams, Partial<HasIdentity>, Partial<OpenCollectionLocParams> {
     locType: LocType;
 }
 
@@ -889,8 +913,21 @@ export abstract class LocRequestState extends State {
                 collectionItemFee: request.fees?.collectionItemFee !== undefined ? Lgnt.fromCanonical(BigInt(request.fees.collectionItemFee)) : undefined,
                 tokensRecordFee: request.fees?.tokensRecordFee !== undefined ? Lgnt.fromCanonical(BigInt(request.fees.tokensRecordFee)) : undefined,
             },
+            collectionParams: this.toCollectionParams(request.collectionParams),
             invitedContributors,
         };
+    }
+
+    static toCollectionParams(collectionParams: BackendCollectionParams | undefined): CollectionParams | undefined {
+        if (collectionParams === undefined) {
+            return undefined;
+        }
+        const { lastBlockSubmission, maxSize, canUpload } = collectionParams;
+        return {
+            lastBlockSubmission: lastBlockSubmission ? BigInt(lastBlockSubmission) : undefined,
+            maxSize: maxSize ? parseInt(maxSize) : undefined,
+            canUpload,
+        }
     }
 
     private static dataFromRequestAndLoc(api: LogionNodeApiClass, request: LocRequest, loc: LegalOfficerCase, locIssuers: LocVerifiedIssuers, invitedContributors: ValidAccountId[]): LocData {
@@ -923,6 +960,11 @@ export abstract class LocRequestState extends State {
                 tokensRecordFee: loc.tokensRecordFee,
             },
             invitedContributors,
+            collectionParams: {
+                lastBlockSubmission: loc.collectionLastBlockSubmission,
+                maxSize: loc.collectionMaxSize,
+                canUpload: loc.collectionCanUpload,
+            }
         };
 
         if(data.voidInfo && request.voidInfo) {
@@ -1447,17 +1489,20 @@ export class AcceptedRequest extends ReviewedRequest {
     async open(parameters: BlockchainSubmissionParams & AutoPublish): Promise<OpenLoc> {
         const { autoPublish } = parameters;
         if (this.request.locType === "Transaction") {
-            await this.locSharedState.client.openTransactionLoc({
+            await this.locSharedState.client.openTransactionLoc(toBlockchainSubmission({
                 ...this.checkOpenParams(autoPublish),
                 ...parameters,
-            })
+            }));
         } else if (this.request.locType === "Identity") {
-            await this.locSharedState.client.openIdentityLoc({
+            await this.locSharedState.client.openIdentityLoc(toBlockchainSubmission({
                 ...this.checkOpenParams(autoPublish),
                 ...parameters,
-            })
+            }));
         } else {
-            throw Error("Collection LOCs are opened with openCollection()");
+            await this.locSharedState.client.openCollectionLoc(toBlockchainSubmission({
+                ...this.checkOpenCollectionParams(autoPublish),
+                ...parameters,
+            }));
         }
         return await this.refresh() as OpenLoc
     }
@@ -1523,60 +1568,36 @@ export class AcceptedRequest extends ReviewedRequest {
         } else if (this.request.locType === "Identity") {
             return this.locSharedState.client.estimateFeesOpenIdentityLoc(this.checkOpenParams(autoPublish))
         } else {
-            throw Error("Collection LOCs fees are estimated with estimateFeesOpenCollection()");
+            return this.locSharedState.client.estimateFeesOpenCollectionLoc(this.checkOpenCollectionParams(autoPublish))
         }
     }
 
-    async openCollection(parameters: CollectionLimits & BlockchainSubmissionParams & AutoPublish): Promise<OpenLoc> {
-        const { autoPublish } = parameters;
-        await this.locSharedState.client.openCollectionLoc({
-            ...this.checkOpenCollectionParams(autoPublish),
-            ...parameters,
-        });
-        return await this.refresh() as OpenLoc;
-    }
-
-    private checkOpenCollectionParams(autoPublish: boolean): OpenPolkadotLocParams & { valueFee: Lgnt, collectionItemFee: Lgnt, tokensRecordFee: Lgnt } & AutoPublish {
+    private checkOpenCollectionParams(autoPublish: boolean): OpenPolkadotLocParams & OpenCollectionLocParams & AutoPublish {
         const requesterAddress = this.request.requesterAddress;
         if (requesterAddress === undefined || requesterAddress?.type !== "Polkadot") {
             throw Error("Only Polkadot requester can open, or estimate fees of, a Collection LOC");
         }
-        const legalFee = this.request.fees?.legalFee;
-        const valueFee = this.request.fees?.valueFee;
-        if(!valueFee) {
-            throw new Error("Missing value fee");
+        const fees = this.request.fees;
+        const legalFee = fees?.legalFee;
+        const valueFee = requireDefined(fees?.valueFee, () => new Error("Missing value fee"));
+        const collectionItemFee = requireDefined(fees?.collectionItemFee, () => new Error("Missing collection item fee"));
+        const tokensRecordFee = requireDefined(fees?.tokensRecordFee, () => new Error("Missing tokens record fee"));
+        const collectionParams = requireDefined(LocRequestState.toCollectionParams(this.request.collectionParams),
+            () => new Error("Missing collection params")
+        );
+        return {
+            locId: this.locId,
+            legalOfficerAddress: this.owner.address,
+            valueFee: Lgnt.fromCanonical(BigInt(valueFee)),
+            collectionItemFee: Lgnt.fromCanonical(BigInt(collectionItemFee)),
+            tokensRecordFee: Lgnt.fromCanonical(BigInt(tokensRecordFee)),
+            legalFee: legalFee !== undefined ? Lgnt.fromCanonical(BigInt(legalFee)) : undefined,
+            metadata: this.toAddMetadataParams(autoPublish),
+            files: this.toAddFileParams(autoPublish),
+            links: this.toAddLinkParams(autoPublish),
+            collectionParams,
+            autoPublish,
         }
-        const collectionItemFee = this.request.fees?.collectionItemFee;
-        if(!collectionItemFee) {
-            throw new Error("Missing collection item fee");
-        }
-        const tokensRecordFee = this.request.fees?.tokensRecordFee;
-        if(!tokensRecordFee) {
-            throw new Error("Missing tokens record fee");
-        }
-        if (this.request.locType === "Collection") {
-            return {
-                locId: this.locId,
-                legalOfficerAddress: this.owner.address,
-                valueFee: Lgnt.fromCanonical(BigInt(valueFee)),
-                collectionItemFee: Lgnt.fromCanonical(BigInt(collectionItemFee)),
-                tokensRecordFee: Lgnt.fromCanonical(BigInt(tokensRecordFee)),
-                legalFee: legalFee !== undefined ? Lgnt.fromCanonical(BigInt(legalFee)) : undefined,
-                metadata: this.toAddMetadataParams(autoPublish),
-                files: this.toAddFileParams(autoPublish),
-                links: this.toAddLinkParams(autoPublish),
-                autoPublish,
-            }
-        } else {
-            throw Error("Other LOCs are opened/estimated with open()/estimateFeesOpen()");
-        }
-    }
-
-    async estimateFeesOpenCollection(parameters: EstimateFeesOpenCollectionLocParams & AutoPublish): Promise<FeesClass> {
-        return this.locSharedState.client.estimateFeesOpenCollectionLoc({
-            ...this.checkOpenCollectionParams(parameters.autoPublish),
-            ...parameters
-        });
     }
 
     withLocs(locsState: LocsState): AcceptedRequest {

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -191,10 +191,10 @@ export interface AddLinkParams {
 }
 
 export function withLocId<T>(locId: UUID, params: BlockchainSubmission<T>): BlockchainSubmission<T & FetchParameters> {
-    return addToPayload({ locId }, params)
+    return withAdditional({ locId }, params)
 }
 
-export function addToPayload<T, P>(additionalPayload: P, params: BlockchainSubmission<T>): BlockchainSubmission<T & P> {
+export function withAdditional<T, P>(additionalPayload: P, params: BlockchainSubmission<T>): BlockchainSubmission<T & P> {
     const { signer, callback, payload } = params;
     return {
         signer,

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -52,7 +52,8 @@ import {
     buildValidPolkadotAccountId,
     ItIsUuid,
     mockCodecWithToString,
-    MOCK_FILE, mockOption, mockEmptyOption
+    MOCK_FILE,
+    mockEmptyOption,
 } from "./Utils.js";
 import { TestConfigFactory } from "./TestConfigFactory.js";
 import {

--- a/packages/client/test/LocClient.spec.ts
+++ b/packages/client/test/LocClient.spec.ts
@@ -19,6 +19,5 @@ describe("LocClient", () => {
         expect(result.signer).toBe(signer);
         expect(result.callback).toBe(callback);
         expect(result.payload).toEqual(someParams);
-        console.log(result)
     })
 })

--- a/packages/client/test/LocClient.spec.ts
+++ b/packages/client/test/LocClient.spec.ts
@@ -1,0 +1,24 @@
+import { Signer, SignCallback, toBlockchainSubmission, BlockchainSubmissionParams } from "../src/index.js";
+import { Mock } from "moq.ts";
+
+describe("LocClient", () => {
+
+    it("toBlockchainSubmission", () => {
+        const signer = new Mock<Signer>().object();
+        const callback = new Mock<SignCallback>().object();
+        const someParams = {
+            a: 123,
+            b: "b",
+        }
+        const params: BlockchainSubmissionParams = {
+            signer,
+            callback,
+            ...someParams,
+        }
+        const result = toBlockchainSubmission(params);
+        expect(result.signer).toBe(signer);
+        expect(result.callback).toBe(callback);
+        expect(result.payload).toEqual(someParams);
+        console.log(result)
+    })
+})


### PR DESCRIPTION
* Collections params (`lastBlockSubmission`, `maxSize`, `canUpload` ) are now provided at collection request step (previously: at open step).
* The specific `openCollection()` is removed, `open()` can be used for any LOC type.
* `CollectionParams` is now encapsulated in `Locdata` and `OpenCollectionLocParams`.
* As done previously, `EstimateFeesOpenCollectionLocParams` is removed and `OpenCollectionLocParams` and `BlockchainSubmission<OpenCollectionLocParams>` are used instead.

logion-network/logion-internal#1179