### PR TITLE
More robust chain time

### DIFF
--- a/packages/node-api/integration/ChainTime.ts
+++ b/packages/node-api/integration/ChainTime.ts
@@ -1,0 +1,9 @@
+import { setup } from "./Util.js";
+
+export async function handleTime() {
+    const { api } = await setup();
+    const time = await api.time.now();
+    const block = time.currentBlock;
+    const nextTime = await time.atBlock(block + 1n);
+    expect(nextTime.currentTime - time.currentTime).toBe(Number(time.slotDuration));
+}

--- a/packages/node-api/integration/Main.spec.ts
+++ b/packages/node-api/integration/Main.spec.ts
@@ -24,6 +24,7 @@ import { storageFees, legalFees, certificateFees, ensureEnoughFunds } from "./Fe
 import { toPalletLogionLocOtherAccountId, toSponsorshipId, toPalletLogionLocMetadataItem, toPalletLogionLocFile, toCollectionItemToken, toCollectionItemFile } from "./Adapters.js";
 import { badOriginError, moduleError } from "./Error.js";
 import { createIdentityLocTest } from "./IdentityLoc.js";
+import { handleTime } from "./ChainTime.js";
 
 describe("Logion Node API", () => {
 
@@ -74,4 +75,6 @@ describe("Logion Node API", () => {
 
     it("supports verified issuers", verifiedIssuers);
     it("supports invited contributors", invitedContributors);
+
+    it("handles time", handleTime);
 });

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.28.4-2",
+  "version": "0.28.4-3",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/ChainTime.ts
+++ b/packages/node-api/src/ChainTime.ts
@@ -4,18 +4,21 @@ export class ChainTime {
 
     static async now(api: ApiPromise): Promise<ChainTime> {
         const currentBlock = await api.rpc.chain.getBlock();
-        return new ChainTime(api, Date.now(), currentBlock.block.header.number.toBigInt());
+        const slotDuration = (await api.call.auraApi.slotDuration()).toBigInt();
+        return new ChainTime(api, Date.now(), currentBlock.block.header.number.toBigInt(), slotDuration);
     }
 
-    constructor(api: ApiPromise, now: number, currentBlock: bigint) {
+    private constructor(api: ApiPromise, now: number, currentBlock: bigint, slotDuration: bigint) {
         this._api = api;
         this._currentTime = now;
         this._currentBlock = currentBlock;
+        this._slotDuration = slotDuration;
     }
 
     private _api: ApiPromise;
     private _currentTime: number;
     private _currentBlock: bigint;
+    private _slotDuration: bigint;
 
     get currentTime(): number {
         return this._currentTime;
@@ -25,19 +28,21 @@ export class ChainTime {
         return this._currentBlock;
     }
 
+    get slotDuration() {
+        return this._slotDuration;
+    }
+
     async atDate(date: Date): Promise<ChainTime> {
         const diffInMs = BigInt(date.getTime() - this._currentTime);
-        const expectedBlockTimeInMs = this._api.consts.timestamp.minimumPeriod.toBigInt() * BigInt(2);
-        const deltaInBlocks = diffInMs / expectedBlockTimeInMs;
+        const deltaInBlocks = diffInMs / this.slotDuration;
         const atBlock = this._currentBlock + deltaInBlocks;
-        return new ChainTime(this._api, date.getTime(), atBlock);
+        return new ChainTime(this._api, date.getTime(), atBlock, this._slotDuration);
     }
 
     async atBlock(blockNumber: bigint): Promise<ChainTime> {
         const diffInBlocks = blockNumber - this._currentBlock;
-        const expectedBlockTimeInMs = this._api.consts.timestamp.minimumPeriod.toBigInt() * BigInt(2);
-        const deltaInMs = diffInBlocks * expectedBlockTimeInMs;
+        const deltaInMs = diffInBlocks * this.slotDuration;
         const atTime = this._currentTime + Number(deltaInMs);
-        return new ChainTime(this._api, atTime, blockNumber);
+        return new ChainTime(this._api, atTime, blockNumber, this._slotDuration);
     }
 }

--- a/packages/node-api/src/Queries.ts
+++ b/packages/node-api/src/Queries.ts
@@ -31,7 +31,7 @@ export interface CoinBalance {
     level: number,
 }
 
-export const ARTIFICIAL_MAX_BALANCE = Currency.toPrefixedNumberAmount(100n);
+export const ARTIFICIAL_MAX_BALANCE = Currency.Lgnt.fromCanonical(100n).toCanonicalPrefixedNumber();
 
 export class Queries {
 
@@ -72,9 +72,9 @@ export class Queries {
         const accountInfo = await this.api.query.system.account(accountId);
         const data = this.adapters.fromFrameSystemAccountInfo(accountInfo);
 
-        const logAvailable = Currency.toPrefixedNumberAmount(BigInt(data.available)).optimizeScale(3);
-        const logReserved = Currency.toPrefixedNumberAmount(BigInt(data.reserved)).optimizeScale(3);
-        const logTotal = Currency.toPrefixedNumberAmount(BigInt(data.total)).optimizeScale(3);
+        const logAvailable = Currency.Lgnt.fromCanonical(BigInt(data.available)).toCanonicalPrefixedNumber().optimizeScale(3);
+        const logReserved = Currency.Lgnt.fromCanonical(BigInt(data.reserved)).toCanonicalPrefixedNumber().optimizeScale(3);
+        const logTotal = Currency.Lgnt.fromCanonical(BigInt(data.total)).toCanonicalPrefixedNumber().optimizeScale(3);
         const logLevel = logTotal.scientificNumber.divideBy(ARTIFICIAL_MAX_BALANCE.convertTo(logTotal.prefix).scientificNumber).toNumber();
 
         return [

--- a/packages/node-api/src/VaultClass.ts
+++ b/packages/node-api/src/VaultClass.ts
@@ -22,6 +22,7 @@ export interface CancelVaultOutTransferParameters extends RequestVaultOutTransfe
 
 export class Vault {
 
+    // Should be taken from runtime, requires https://github.com/logion-network/logion-internal/issues/1193
     static readonly THRESHOLD = 2;
 
     constructor(

--- a/packages/node-api/test/ChainTime.spec.ts
+++ b/packages/node-api/test/ChainTime.spec.ts
@@ -65,11 +65,11 @@ describe("ChainTime", () => {
 
 function buildPolkadotApiForTime() {
     return {
-        consts: {
-            timestamp: {
-                minimumPeriod: {
-                    toBigInt: () => BigInt(3000)
-                }
+        call: {
+            auraApi: {
+                slotDuration: () => Promise.resolve({
+                    toBigInt: () => 6000n
+                }),
             }
         },
 


### PR DESCRIPTION
* Chain time now only relies on the slot duration returned by the runtime (no more client-side computation).
* Removes a couple of deprecated calls in `Queries`.
* Left a comment about how to make `Vault` more robust (but requires runtime-side changes).