### PR TITLE
Remove dependency to Api in Any/ValidAccountId.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.42.1-1",
+  "version": "0.42.1-2",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/AuthenticationClient.ts
+++ b/packages/client/src/AuthenticationClient.ts
@@ -149,7 +149,7 @@ export class AccountTokens {
     }
 
     get addresses(): ValidAccountId[] {
-        return Object.keys(this.store).map(key => ValidAccountId.parseKey(this.api.polkadot, key));
+        return Object.keys(this.store).map(key => ValidAccountId.parseKey(key));
     }
 
     cleanUp(now: DateTime): AccountTokens {

--- a/packages/client/test/Utils.ts
+++ b/packages/client/test/Utils.ts
@@ -236,8 +236,7 @@ export function buildValidPolkadotAccountId(address: string | undefined): ValidA
 
 export function buildValidAccountId(address: string | undefined, type: AccountType): ValidAccountId | undefined {
     if(address) {
-        const api = buildSimpleNodeApi();
-        return new AnyAccountId(api.polkadot, address, type).toValidAccountId();
+        return new AnyAccountId(address, type).toValidAccountId();
     } else {
         return undefined;
     }
@@ -245,17 +244,9 @@ export function buildValidAccountId(address: string | undefined, type: AccountTy
 
 export function buildSimpleNodeApi(): LogionNodeApiClass {
     const api = {
-        createType: () => undefined,
         runtimeVersion: {
             specName: { toString: () => "logion" },
             specVersion: { toBigInt: () => 3000n },
-        },
-        consts: {
-            system: {
-                ss58Prefix: {
-                    toNumber: () => SS58_PREFIX
-                }
-            }
         },
     } as unknown as ApiPromise;
     return new LogionNodeApiClass(api);

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.29.0-1",
+  "version": "0.29.0-2",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/Adapters.ts
+++ b/packages/node-api/src/Adapters.ts
@@ -90,10 +90,10 @@ export class Adapters {
     fromPalletLogionLocLegalOfficerCase(rawLoc: PalletLogionLocLegalOfficerCase): LegalOfficerCase {
         let requesterAddress: ValidAccountId | undefined;
         if(rawLoc.requester.isAccount) {
-            requesterAddress = new AnyAccountId(this.api, rawLoc.requester.asAccount.toString(), "Polkadot").toValidAccountId();
+            requesterAddress = new AnyAccountId(rawLoc.requester.asAccount.toString(), "Polkadot").toValidAccountId();
         } else if(rawLoc.requester.isOtherAccount) {
             if(rawLoc.requester.asOtherAccount.isEthereum) {
-                requesterAddress = new AnyAccountId(this.api, rawLoc.requester.asOtherAccount.asEthereum.toHex(), "Ethereum").toValidAccountId();
+                requesterAddress = new AnyAccountId(rawLoc.requester.asOtherAccount.asEthereum.toHex(), "Ethereum").toValidAccountId();
             } else {
                 throw new Error("Unsupported other account value");
             }
@@ -409,10 +409,10 @@ export class Adapters {
 
     fromPalletLogionLocSupportedAccountId(accountId: PalletLogionLocSupportedAccountId): ValidAccountId {
         if(accountId.isPolkadot) {
-            return new AnyAccountId(this.api, accountId.asPolkadot.toString(), "Polkadot").toValidAccountId();
+            return new AnyAccountId(accountId.asPolkadot.toString(), "Polkadot").toValidAccountId();
         } else if(accountId.isOther) {
             if(accountId.asOther.isEthereum) {
-                return new AnyAccountId(this.api, accountId.asOther.asEthereum.toHex(), "Ethereum").toValidAccountId();
+                return new AnyAccountId(accountId.asOther.asEthereum.toHex(), "Ethereum").toValidAccountId();
             } else {
                 throw new Error(`Unsupported account type ${accountId.asOther.type}`);
             }
@@ -558,7 +558,7 @@ export class Adapters {
     }
 
     getValidAccountId(accountId: string, type: AccountType): ValidAccountId {
-        const anyAccountId = new AnyAccountId(this.api, accountId, type);
+        const anyAccountId = new AnyAccountId(accountId, type);
         return anyAccountId.toValidAccountId();
     }
 

--- a/packages/node-api/src/Connection.ts
+++ b/packages/node-api/src/Connection.ts
@@ -14,6 +14,7 @@ import { LocBatch } from './LocBatch.js';
 import { UUID } from './UUID.js';
 import { LegalOfficerCase, VerifiedIssuerType, SS58_PREFIX } from './Types.js';
 import { Batching } from "./Batching.js";
+import { Lgnt } from "./Currency.js"
 
 export type ChainType = "Solo" | "Para";
 
@@ -46,7 +47,11 @@ export class LogionNodeApiClass {
         });
         const chainPrefix = api.consts.system.ss58Prefix.toNumber();
         if (chainPrefix !== SS58_PREFIX) {
-            throw new Error(`Chain Prefix ${ chainPrefix } differs from public constant ${ SS58_PREFIX }`);
+            throw new Error(`Chain Prefix ${ chainPrefix } differs from public constant SS58_PREFIX = ${ SS58_PREFIX }`);
+        }
+        const chainDecimals = (await api.rpc.system.properties()).tokenDecimals.unwrap()[0].toNumber();
+        if (chainDecimals !== Lgnt.DECIMALS) {
+            throw new Error(`Chain Decimals ${ chainDecimals } differs from public constant Lgnt.DECIMALS = ${ Lgnt.DECIMALS }`);
         }
         return new LogionNodeApiClass(api);
     }

--- a/packages/node-api/src/Connection.ts
+++ b/packages/node-api/src/Connection.ts
@@ -12,7 +12,7 @@ import { ChainTime } from './ChainTime.js';
 import { Vault } from './VaultClass.js';
 import { LocBatch } from './LocBatch.js';
 import { UUID } from './UUID.js';
-import { LegalOfficerCase, VerifiedIssuerType } from './Types.js';
+import { LegalOfficerCase, VerifiedIssuerType, SS58_PREFIX } from './Types.js';
 import { Batching } from "./Batching.js";
 
 export type ChainType = "Solo" | "Para";
@@ -44,6 +44,10 @@ export class LogionNodeApiClass {
             rpc: jsonrpc,
             runtime: definitions.runtime.runtime,
         });
+        const chainPrefix = api.consts.system.ss58Prefix.toNumber();
+        if (chainPrefix !== SS58_PREFIX) {
+            throw new Error(`Chain Prefix ${ chainPrefix } differs from public constant ${ SS58_PREFIX }`);
+        }
         return new LogionNodeApiClass(api);
     }
 

--- a/packages/node-api/src/Queries.ts
+++ b/packages/node-api/src/Queries.ts
@@ -55,7 +55,7 @@ export class Queries {
         if(accountId === null || accountId === undefined || accountId === '') {
             return false;
         }
-        const anyAccountId = new AnyAccountId(this.api, accountId, type || "Polkadot");
+        const anyAccountId = new AnyAccountId(accountId, type || "Polkadot");
         return anyAccountId.isValid();
     }
 

--- a/packages/node-api/test/Queries.spec.ts
+++ b/packages/node-api/test/Queries.spec.ts
@@ -4,7 +4,7 @@ import {
     POLKADOT_API_CREATE_TYPE,
     mockValidAccountId,
     mockBool,
-    mockParaRuntimeVersion, SS58_PREFIX,
+    mockParaRuntimeVersion,
 } from "./Util.js";
 import { DEFAULT_LEGAL_OFFICER } from "./TestData.js";
 import { BN } from "bn.js";
@@ -151,13 +151,6 @@ function mockPolkadotApiWithAccountData(accountId: string) {
 function mockPolkadotApiForLogionLoc() {
     return {
         runtimeVersion: mockParaRuntimeVersion(),
-        consts: {
-            system: {
-                ss58Prefix: {
-                    toNumber: () => SS58_PREFIX
-                }
-            }
-        },
         query: {
             logionLoc: {
                 locMap: () => Promise.resolve({

--- a/packages/node-api/test/Types.spec.ts
+++ b/packages/node-api/test/Types.spec.ts
@@ -1,6 +1,4 @@
 import { ValidAccountId, AnyAccountId } from "../src/index.js";
-import { ApiPromise } from "@polkadot/api";
-import { POLKADOT_API_CREATE_TYPE, SS58_PREFIX } from "./Util.js";
 
 describe("ValidAccountId", () => {
 
@@ -8,8 +6,7 @@ describe("ValidAccountId", () => {
     const address2021 = "vQxmTQGRHbTsBdDhVLqsksX7c44K8DjVokJUi8ZK58z88tDBx";
 
     function getAccount(address: string): ValidAccountId {
-        const api = mockApi();
-        const account = new AnyAccountId(api, address, "Polkadot").toValidAccountId();
+        const account = new AnyAccountId(address, "Polkadot").toValidAccountId();
         expect(account.type).toEqual("Polkadot");
         expect(account.address).toEqual(address2021);
         expect(account.getAddress(42)).toEqual(address42);
@@ -29,28 +26,24 @@ describe("ValidAccountId", () => {
         const anotherAddress42 = "5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS9WvBNzyJ9q7gtwtG";
         const anotherAddress2021 = "vQxanie8kdmBrdYoH7GAHXb8RWi8J3hyLePK3fyyV3a84iNXA";
 
-        const api = mockApi();
-        const account1 = new AnyAccountId(api, address42, "Polkadot").toValidAccountId();
+        const account1 = new AnyAccountId(address42, "Polkadot").toValidAccountId();
 
-        const account2 = new AnyAccountId(api, anotherAddress42, "Polkadot").toValidAccountId();
+        const account2 = new AnyAccountId(anotherAddress42, "Polkadot").toValidAccountId();
         expect(account1.equals(account2)).toBeFalse();
         expect(account2.equals(account1)).toBeFalse();
 
-        const account3 = new AnyAccountId(api, anotherAddress2021, "Polkadot").toValidAccountId();
+        const account3 = new AnyAccountId(anotherAddress2021, "Polkadot").toValidAccountId();
         expect(account1.equals(account3)).toBeFalse();
         expect(account3.equals(account1)).toBeFalse();
     })
-})
 
-function mockApi() {
-    return {
-        consts: {
-            system: {
-                ss58Prefix: {
-                    toNumber: () => SS58_PREFIX
-                }
-            }
-        },
-        createType: POLKADOT_API_CREATE_TYPE,
-    } as unknown as ApiPromise;
-}
+    it("does not validate an invalid account", () => {
+        expect(new AnyAccountId("BLA", "Polkadot").validate())
+            .toEqual("Wrong Polkadot address BLA: Error: Decoding BLA: Invalid decoded address length")
+        expect(new AnyAccountId("INVALID", "Polkadot").validate())
+            .toEqual('Wrong Polkadot address INVALID: Error: Decoding INVALID: Invalid base58 character "I" (0x49) at index 0')
+        const invalid = "5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS8888888888888888";
+        expect(new AnyAccountId(invalid, "Polkadot").validate())
+            .toEqual("Wrong Polkadot address 5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS8888888888888888: Error: Decoding 5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS8888888888888888: Invalid decoded address checksum")
+    })
+})

--- a/packages/node-api/test/Util.ts
+++ b/packages/node-api/test/Util.ts
@@ -2,10 +2,6 @@ import type { Codec } from '@polkadot/types-codec/types';
 import { AnyAccountId, EXPECTED_PARA_VERSION, EXPECTED_SOLO_VERSION, EXPECTED_SPEC_NAME, ValidAccountId } from '../src/index.js';
 import { bool } from "@polkadot/types-codec";
 
-export function createdPolkadotType(content: object): any {
-    return jasmine.arrayContaining([jasmine.objectContaining(content)]);
-}
-
 export function mockCodecWithToString<T extends Codec>(value: string): T {
     return ({
         toString: () => value,
@@ -18,20 +14,8 @@ export function mockCodecWithToBigInt<T>(value: bigint): T {
     }) as T;
 }
 
-export const SS58_PREFIX = 2021;
-
 export function mockValidAccountId(address: string): ValidAccountId {
-    const api = {
-        createType: (_type: string, ...args: any[]) => args,
-        consts: {
-            system: {
-                ss58Prefix: {
-                    toNumber: () => SS58_PREFIX
-                }
-            }
-        }
-    } as any;
-    return new AnyAccountId(api, address, "Polkadot").toValidAccountId();
+    return new AnyAccountId(address, "Polkadot").toValidAccountId();
 }
 
 export const POLKADOT_API_CREATE_TYPE = (_type: string, ...args: any[]) => args;


### PR DESCRIPTION
* SS58Prefix is a public constant, validated at startup.
* `createType()` is replaced with `validateAddress()` from `crypto-util`.

logion-network/logion-internal#1218