### PR TITLE
Refactor transactions

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.43.0-1",
+  "version": "0.43.0-2",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",


### PR DESCRIPTION
* Distinguish backend and client transactions.
* Use `ValidAccountId` in client transactions.

logion-network/logion-internal#1216