### PR TITLE
Various fixes for para

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.43.0-2",
+  "version": "0.43.0-3",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Environment.ts
+++ b/packages/client/src/Environment.ts
@@ -10,20 +10,20 @@ export enum Environment {
 
 const configs: Record<Environment, Omit<LogionClientConfig, 'buildFileUploader'>> = {
     DEV: {
-        rpcEndpoints: [ "wss://dev-rpc01.logion.network" ],
+        rpcEndpoints: [ "wss://dev-para-rpc01.logion.network" ],
         directoryEndpoint: "https://dev-directory.logion.network",
         logionClassificationLoc: UUID.fromDecimalStringOrThrow("229858905135790300364920790577257842944"),
         creativeCommonsLoc: UUID.fromDecimalStringOrThrow("238252136510269500314784833180701623867"),
     },
     TEST: {
-        rpcEndpoints: [ "wss://test-rpc01.logion.network" ],
+        rpcEndpoints: [ "wss://test-para-rpc01.logion.network" ],
         directoryEndpoint: "https://test-directory.logion.network",
         logionClassificationLoc: UUID.fromDecimalStringOrThrow("116468287775993067124760331735250695835"),
     },
     MVP: {
         rpcEndpoints: [
-            "wss://rpc01.logion.network",
-            "wss://rpc02.logion.network",
+            "wss://para-rpc01.logion.network",
+            "wss://para-rpc02.logion.network",
         ],
         directoryEndpoint: "https://directory.logion.network",
         logionClassificationLoc: UUID.fromDecimalStringOrThrow("85815882149698756717105061322008904805"),

--- a/packages/client/src/Recovery.ts
+++ b/packages/client/src/Recovery.ts
@@ -334,7 +334,7 @@ export interface ProtectionParameters {
 
     readonly postalAddress?: PostalAddress; // Only defined on recovery
 
-    readonly recoveredAddress: ValidAccountId | undefined;
+    readonly recoveredAccount: ValidAccountId | undefined;
 
     readonly isRecovery: boolean;
 
@@ -364,7 +364,7 @@ function buildProtectionParameters(sharedState: RecoverySharedState): Protection
         states,
         postalAddress: request1?.userPostalAddress,
         userIdentity: request1?.userIdentity,
-        recoveredAddress: request1?.addressToRecover ? ValidAccountId.polkadot(request1?.addressToRecover) : undefined,
+        recoveredAccount: request1?.addressToRecover ? ValidAccountId.polkadot(request1?.addressToRecover) : undefined,
         isRecovery,
         isActive: sharedState.recoveryConfig !== undefined,
         isClaimed: sharedState.recoveredAddress !== undefined,
@@ -686,7 +686,7 @@ export class PendingRecovery extends State implements WithProtectionParameters, 
 
     private async _claimRecovery(params: BlockchainSubmissionParams): Promise<ClaimedRecovery> {
         const { signer, callback } = params;
-        const addressToRecover = this.protectionParameters.recoveredAddress;
+        const addressToRecover = this.protectionParameters.recoveredAccount;
         await signer.signAndSend({
             signerId: getDefinedCurrentAccount(this.sharedState),
             submittable: this.sharedState.nodeApi.polkadot.tx.recovery.claimRecovery(addressToRecover?.address || ""),

--- a/packages/client/test/Environment.spec.ts
+++ b/packages/client/test/Environment.spec.ts
@@ -13,13 +13,13 @@ describe("Environment", () => {
     it("creates config from environment", () => {
         const config = createLogionClientConfig(Environment.TEST, () => fileUploader);
         expect(config.directoryEndpoint).toEqual("https://test-directory.logion.network");
-        expect(config.rpcEndpoints).toEqual([ "wss://test-rpc01.logion.network" ]);
+        expect(config.rpcEndpoints).toEqual([ "wss://test-para-rpc01.logion.network" ]);
     })
 
     it("creates config from environment string", () => {
         const config = createLogionClientConfig("TEST", () => fileUploader);
         expect(config.directoryEndpoint).toEqual("https://test-directory.logion.network");
-        expect(config.rpcEndpoints).toEqual([ "wss://test-rpc01.logion.network" ]);
+        expect(config.rpcEndpoints).toEqual([ "wss://test-para-rpc01.logion.network" ]);
     })
 
     it("fails to create config from unknown environment", () => {

--- a/packages/client/test/Utils.ts
+++ b/packages/client/test/Utils.ts
@@ -248,6 +248,11 @@ export function buildSimpleNodeApi(): LogionNodeApiClass {
             specName: { toString: () => "logion" },
             specVersion: { toBigInt: () => 3000n },
         },
+        consts: {
+            system: {
+                ss58Prefix: { toNumber: () => 2021 }
+            }
+        }
     } as unknown as ApiPromise;
     return new LogionNodeApiClass(api);
 }

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.29.0-4",
+  "version": "0.29.0-5",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/node-api/src/Connection.ts
+++ b/packages/node-api/src/Connection.ts
@@ -45,15 +45,15 @@ export class LogionNodeApiClass {
             rpc: jsonrpc,
             runtime: definitions.runtime.runtime,
         });
-        const chainPrefix = api.consts.system.ss58Prefix.toNumber();
-        if (chainPrefix !== SS58_PREFIX) {
-            throw new Error(`Chain Prefix ${ chainPrefix } differs from public constant SS58_PREFIX = ${ SS58_PREFIX }`);
-        }
+
+        const logionApi = new LogionNodeApiClass(api);
+
         const chainDecimals = (await api.rpc.system.properties()).tokenDecimals.unwrap()[0].toNumber();
         if (chainDecimals !== Lgnt.DECIMALS) {
             throw new Error(`Chain Decimals ${ chainDecimals } differs from public constant Lgnt.DECIMALS = ${ Lgnt.DECIMALS }`);
         }
-        return new LogionNodeApiClass(api);
+
+        return logionApi;
     }
 
     private static buildProvider(endpoint: string | string[]): WsProvider {
@@ -72,6 +72,10 @@ export class LogionNodeApiClass {
         this.chainType = this.detectChainType();
         if(this.chainType !== "Para") {
             throw new Error(`This version of the SDK does not have support for chain type ${ this.chainType }`);
+        }
+        const chainPrefix = api.consts.system.ss58Prefix.toNumber();
+        if (chainPrefix !== SS58_PREFIX) {
+            throw new Error(`Chain Prefix ${ chainPrefix } differs from public constant SS58_PREFIX = ${ SS58_PREFIX }`);
         }
         this.adapters = new Adapters(api);
         this.fees = new FeesEstimator(api);

--- a/packages/node-api/test/Connection.spec.ts
+++ b/packages/node-api/test/Connection.spec.ts
@@ -1,15 +1,24 @@
 import { ApiPromise } from "@polkadot/api";
 import { LogionNodeApiClass } from "../src/index.js";
-import { mockParaRuntimeVersion, mockRuntimeVersionUnexpectedSpecName, mockRuntimeVersionUnexpectedSpecVersion, mockSoloRuntimeVersion } from "./Util.js";
+import { mockConsts, mockParaConsts, mockParaRuntimeVersion, mockRuntimeVersionUnexpectedSpecName, mockRuntimeVersionUnexpectedSpecVersion, mockSoloRuntimeVersion } from "./Util.js";
 
 describe("LogionNodeApiClass", () => {
 
     it("detects para chain", () => {
         const polkadot = {
             runtimeVersion: mockParaRuntimeVersion(),
+            consts: mockParaConsts(),
         } as unknown as ApiPromise;
         const api = new LogionNodeApiClass(polkadot);
         expect(api.chainType).toBe("Para");
+    });
+
+    it("fails connecting to para chain with wrong SS58 prefix", () => {
+        const polkadot = {
+            runtimeVersion: mockParaRuntimeVersion(),
+            consts: mockConsts(42),
+        } as unknown as ApiPromise;
+        expect(() => new LogionNodeApiClass(polkadot)).toThrowError("Chain Prefix 42 differs from public constant SS58_PREFIX = 2021");
     });
 
     it("fails connecting to solo chain", () => {

--- a/packages/node-api/test/Queries.spec.ts
+++ b/packages/node-api/test/Queries.spec.ts
@@ -3,6 +3,7 @@ import { CollectionItem, Hash, LegalOfficerCase, Lgnt, LogionNodeApiClass, Numbe
 import {
     POLKADOT_API_CREATE_TYPE,
     mockBool,
+    mockParaConsts,
     mockParaRuntimeVersion,
 } from "./Util.js";
 import { DEFAULT_LEGAL_OFFICER, TEST_WALLET_USER, TEST_WALLET_USER2 } from "./TestData.js";
@@ -129,6 +130,7 @@ describe("Queries", () => {
 function mockPolkadotApiWithAccountData(accountId: ValidAccountId) {
     return {
         runtimeVersion: mockParaRuntimeVersion(),
+        consts: mockParaConsts(),
         query: {
             system: {
                 account: (id: string) => id === accountId.address ? {
@@ -150,6 +152,7 @@ function mockPolkadotApiWithAccountData(accountId: ValidAccountId) {
 function mockPolkadotApiForLogionLoc() {
     return {
         runtimeVersion: mockParaRuntimeVersion(),
+        consts: mockParaConsts(),
         query: {
             logionLoc: {
                 locMap: () => Promise.resolve({
@@ -353,6 +356,7 @@ export const DEFAULT_ITEM: CollectionItem = {
 function mockPolkadotApiForRecovery(recoverable?: any, activeRecoveries?: any) {
     return {
         runtimeVersion: mockParaRuntimeVersion(),
+        consts: mockParaConsts(),
         query: {
             recovery: {
                 recoverable: recoverable ? recoverable : () => Promise.resolve(),

--- a/packages/node-api/test/Util.ts
+++ b/packages/node-api/test/Util.ts
@@ -1,5 +1,5 @@
 import type { Codec } from '@polkadot/types-codec/types';
-import { AnyAccountId, EXPECTED_PARA_VERSION, EXPECTED_SOLO_VERSION, EXPECTED_SPEC_NAME, ValidAccountId } from '../src/index.js';
+import { EXPECTED_PARA_VERSION, EXPECTED_SOLO_VERSION, EXPECTED_SPEC_NAME, SS58_PREFIX } from '../src/index.js';
 import { bool } from "@polkadot/types-codec";
 
 export function mockCodecWithToString<T extends Codec>(value: string): T {
@@ -64,5 +64,19 @@ export function mockRuntimeVersionUnexpectedSpecVersion() {
         specVersion: {
             toBigInt: () => 42n,
         },
+    };
+}
+
+export function mockParaConsts() {
+    return mockConsts(SS58_PREFIX);
+}
+
+export function mockConsts(ss58Prefix: number) {
+    return {
+        system: {
+            ss58Prefix: {
+                toNumber: () => ss58Prefix,
+            }
+        }
     };
 }


### PR DESCRIPTION
* Switches environments to para endpoints.
* Improves connection checks (prefix and digits are validated after chain type).
* Renames `recoveredAddress` to `recoveredAccount`.

logion-network/logion-internal#1216