### PR TITLE
Add support for other account types.

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.43.0-5",
+  "version": "0.43.0-6",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Token.ts
+++ b/packages/client/src/Token.ts
@@ -1,4 +1,4 @@
-import { LogionNodeApiClass, AnyAccountId } from "@logion/node-api";
+import { LogionNodeApiClass, ValidAccountId } from "@logion/node-api";
 import { isHex } from "@polkadot/util";
 
 export interface ItemTokenWithRestrictedType {
@@ -95,7 +95,7 @@ export function validateToken(api: LogionNodeApiClass, itemToken: ItemTokenWithR
                     error: "token ID's 'id' field is not a string",
                 };
             }
-            
+
             return { valid: true };
         } else {
             return result;
@@ -103,10 +103,7 @@ export function validateToken(api: LogionNodeApiClass, itemToken: ItemTokenWithR
     } else if(itemToken.type.includes("erc20")) {
         return validateErcToken(itemToken).result;
     } else if(itemToken.type === "owner") {
-        if (
-            isHex(itemToken.id, ETHEREUM_ADDRESS_LENGTH_IN_BITS) ||
-            AnyAccountId.isValidBech32Address(itemToken.id, "erd1") ||
-            api.queries.isValidAccountId(itemToken.id)) {
+        if (ValidAccountId.fromUnknown(itemToken.id) !== undefined) {
             return { valid: true };
         } else {
             return {
@@ -145,8 +142,6 @@ export function validateToken(api: LogionNodeApiClass, itemToken: ItemTokenWithR
 export function isErcNft(type: TokenType): boolean {
     return type.includes("erc721") || type.includes("erc1155");
 }
-
-const ETHEREUM_ADDRESS_LENGTH_IN_BITS = 20 * 8;
 
 export function validateErcToken(itemToken: ItemTokenWithRestrictedType): { result: TokenValidationResult, idObject?: any } { // eslint-disable-line @typescript-eslint/no-explicit-any
     let idObject;

--- a/packages/node-api/package.json
+++ b/packages/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/node-api",
-  "version": "0.29.0-6",
+  "version": "0.29.0-7",
   "description": "logion API",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
@@ -47,6 +47,7 @@
     "@polkadot/util": "^12.6.2",
     "@polkadot/util-crypto": "^12.6.2",
     "@types/uuid": "^9.0.2",
+    "bech32": "^2.0.0",
     "fast-sha256": "^1.3.0",
     "uuid": "^9.0.0"
   },

--- a/packages/node-api/test/Types.spec.ts
+++ b/packages/node-api/test/Types.spec.ts
@@ -1,6 +1,58 @@
 import { ValidAccountId, AnyAccountId } from "../src/index.js";
 
-describe("ValidAccountId", () => {
+describe("ValidAccountId (Bech32)", () => {
+
+    const address1 = "erd1sqcp77ll8v8j6vgs5m0h2xxkz5wv26pfj2vyyls52cz6hdumkmjq0jr93a";
+    const address2 = "ERD1SQCP77LL8V8J6VGS5M0H2XXKZ5WV26PFJ2VYYLS52CZ6HDUMKMJQ0JR93A";
+
+    it("is valid and not case-sensitive", () => {
+        const account1 = ValidAccountId.bech32(address1);
+        const account2 = ValidAccountId.bech32(address2);
+
+        expect(account1.equals(account1)).toBeTrue();
+        expect(account1.equals(account2)).toBeTrue();
+
+        expect(account2.equals(account1)).toBeTrue();
+        expect(account2.equals(account2)).toBeTrue();
+    })
+
+    it("guesses from unknown", () => {
+        expect(ValidAccountId.fromUnknown(address1)?.type).toEqual("Bech32");
+        expect(ValidAccountId.fromUnknown(address2)?.type).toEqual("Bech32");
+    })
+})
+
+describe("ValidAccountId (Ethereum)", () => {
+
+    const address1 = "0x6ef154673a6379b2CDEDeD6aF1c0d705c3c8272a";
+    const address2 = "0x6ef154673a6379b2cdeded6af1c0d705c3c8272a";
+    const address3 = "0x6EF154673A6379B2CDEDED6AF1C0D705C3C8272A";
+
+    it("is valid and not case-sensitive", () => {
+        const account1 = ValidAccountId.ethereum(address1);
+        const account2 = ValidAccountId.ethereum(address2);
+        const account3 = ValidAccountId.ethereum(address3);
+
+        expect(account1.equals(account1)).toBeTrue();
+        expect(account1.equals(account2)).toBeTrue();
+        expect(account1.equals(account3)).toBeTrue();
+
+        expect(account2.equals(account1)).toBeTrue();
+        expect(account2.equals(account2)).toBeTrue();
+        expect(account2.equals(account3)).toBeTrue();
+
+        expect(account3.equals(account1)).toBeTrue();
+        expect(account3.equals(account2)).toBeTrue();
+        expect(account3.equals(account3)).toBeTrue();
+    })
+
+    it("guesses from unknown", () => {
+        expect(ValidAccountId.fromUnknown(address1)?.type).toEqual("Ethereum");
+        expect(ValidAccountId.fromUnknown(address2)?.type).toEqual("Ethereum");
+    })
+})
+
+describe("ValidAccountId (Polkadot)", () => {
 
     const address42 = "5HYf6QFkYpso8FdX9WALCmRTcga7YSmuFS5qqaJtFF7m4RPr";
     const address2021 = "vQxmTQGRHbTsBdDhVLqsksX7c44K8DjVokJUi8ZK58z88tDBx";
@@ -39,11 +91,26 @@ describe("ValidAccountId", () => {
 
     it("does not validate an invalid account", () => {
         expect(new AnyAccountId("BLA", "Polkadot").validate())
-            .toEqual("Wrong Polkadot address BLA: Error: Decoding BLA: Invalid decoded address length")
+            .toEqual("Wrong Polkadot address BLA: Invalid decoded address")
         expect(new AnyAccountId("INVALID", "Polkadot").validate())
-            .toEqual('Wrong Polkadot address INVALID: Error: Decoding INVALID: Invalid base58 character "I" (0x49) at index 0')
+            .toEqual('Wrong Polkadot address INVALID: Invalid base58 character "I" (0x49) at index 0')
         const invalid = "5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS8888888888888888";
         expect(new AnyAccountId(invalid, "Polkadot").validate())
-            .toEqual("Wrong Polkadot address 5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS8888888888888888: Error: Decoding 5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS8888888888888888: Invalid decoded address checksum")
+            .toEqual("Wrong Polkadot address 5HMzQmyDb8CU8ajJuvSrrqSH5LPHNRFS8888888888888888: Invalid decoded address")
+    })
+
+    it("guesses from unknown", () => {
+        expect(ValidAccountId.fromUnknown(address42)?.type).toEqual("Polkadot");
+        expect(ValidAccountId.fromUnknown(address2021)?.type).toEqual("Polkadot");
     })
 })
+
+describe("ValidAccountId: fromUnknown()", () => {
+
+    it("returns undefined", () => {
+        expect(ValidAccountId.fromUnknown("BLA")).toBeUndefined();
+        expect(ValidAccountId.fromUnknown("INVALID")).toBeUndefined();
+        expect(ValidAccountId.fromUnknown("0x0000")).toBeUndefined();
+    });
+})
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -3077,6 +3077,7 @@ __metadata:
     "@types/uuid": ^9.0.2
     "@typescript-eslint/eslint-plugin": ^6.9.1
     "@typescript-eslint/parser": ^6.9.1
+    bech32: ^2.0.0
     eslint: ^8.20.0
     fast-sha256: ^1.3.0
     jasmine: ^4.3.0


### PR DESCRIPTION
* Add support for other account types
* Add method `fromUnknown()` - aiming at detecting account type from address.
* Provide strong validation of Bech32 addresses - otherwise almost any dummy addresses were accepted as valid Bech32 addresses. (using [bitcoinjs/bech32](https://github.com/bitcoinjs/bech32))
* Provide a stronger validation for Polkadot addresses - for some reasons the previous implementation using [validateAddress()](https://github.com/polkadot-js/common/blob/master/packages/util-crypto/src/address/validate.ts) used to validate addresses that were later on unable to decode. The new implementation is strongly inspired from [checkAddress()](https://github.com/polkadot-js/common/blob/master/packages/util-crypto/src/address/check.ts)

logion-network/logion-internal#1216