### PR TITLE
Show only on-chain collection items

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.43.0",
+  "version": "0.43.1-1",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -612,11 +612,6 @@ export abstract class LocClient {
         const { locId } = parameters;
         const onchainItems = await this.nodeApi.queries.getCollectionItems(locId);
 
-        const onchainItemsMap: Record<string, CollectionItem> = {};
-        for(const item of onchainItems) {
-            onchainItemsMap[item.id.toHex()] = item;
-        }
-
         try {
             const offchainItems = await this.getOffchainItems({ locId });
 
@@ -625,7 +620,7 @@ export abstract class LocClient {
                 offchainItemsMap[item.itemId] = item;
             }
 
-            return offchainItems.map(item => this.mergeItems(onchainItemsMap[item.itemId], offchainItemsMap[item.itemId]));
+            return onchainItems.map(item => this.mergeItems(item, offchainItemsMap[item.id.toHex()]));
         } catch(e) {
             throw newBackendError(e);
         }

--- a/packages/client/src/license/Factory.ts
+++ b/packages/client/src/license/Factory.ts
@@ -38,7 +38,8 @@ export class MergedTermsAndConditionsElement {
 
 /**
  * Creates a new Terms and Conditions, based on given type.
- * @param termsAndConditions the Terms and Conditions elements, as stored on the chain.
+ * @param onchainTCs the Terms and Conditions elements, as stored on the chain.
+ * @param offchainTCs the Terms and Conditions elements, as stored on the off-chain backend.
  * @return an array of terms and conditions element
  * @group TermsAndConditions
  */


### PR DESCRIPTION
* `getCollectionItems()` return only items present on-chain. 

This fixes the problem logion-network/logion-internal#1225 where all items are hidden when some item is not written on-chain(typically lack of funds or signature cancelled), and for some reason (typically browser refresh or close) the cancel to backend is not performed.

Also fixed minor glitch in TS-doc.