### PR TITLE
Expose non-void IDLOCs

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.43.1-2",
+  "version": "0.43.1-4",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -215,6 +215,17 @@ export class LocsState extends State {
         return this.sharedState.legalOfficers.filter(lo => this.hasValidIdentityLoc(lo));
     }
 
+    hasNonVoidIdentityLoc(legalOfficer: LegalOfficer): boolean {
+        return LocsState.filter(this._locs, 'Identity', loc =>
+            loc.data().ownerAccountId.equals(legalOfficer.account)
+            && loc.data().voidInfo === undefined
+        ).length > 0;
+    }
+
+    get legalOfficersWithNonVoidIdentityLoc(): LegalOfficerClass[] {
+        return this.sharedState.legalOfficers.filter(lo => this.hasNonVoidIdentityLoc(lo));
+    }
+
     private static withPredicate<T extends LocRequestState>(locs: Record<string, LocRequestState>, predicate: (l: LocRequestState) => boolean): Record<LocType, T[]> {
         return {
             'Transaction': LocsState.filter(locs, 'Transaction', predicate),

--- a/packages/client/test/Loc.spec.ts
+++ b/packages/client/test/Loc.spec.ts
@@ -90,6 +90,19 @@ describe("LocsState", () => {
         expect(locs.legalOfficersWithValidIdentityLoc[0].account).toEqual(BOB.account);
     })
 
+    it("checks that user has non-void identity", async() => {
+        const sharedState = await buildSharedState();
+        const locs = await LocsState.getInitialLocsState(sharedState, client.object());
+
+        expect(locs.hasNonVoidIdentityLoc(ALICE)).toBeFalse();
+        expect(locs.hasNonVoidIdentityLoc(BOB)).toBeTrue();
+        expect(locs.hasNonVoidIdentityLoc(CHARLIE)).toBeFalse();
+
+        expect(locs.legalOfficersWithNonVoidIdentityLoc.length).toEqual(1);
+        expect(locs.legalOfficersWithNonVoidIdentityLoc[0]).toBeInstanceOf(LegalOfficerClass);
+        expect(locs.legalOfficersWithNonVoidIdentityLoc[0].account).toEqual(BOB.account);
+    })
+
     it("detects that user is not a verified issuer", async() => {
         const sharedState = await buildSharedState();
         const locs = await LocsState.getInitialLocsState(sharedState, client.object());


### PR DESCRIPTION
* Adds `hasNonVoidIdentityLoc` and `legalOfficersWithNonVoidIdentityLoc` to `LocsState`.

logion-network/logion-internal#1239