### PR TITLE
Use backend secrets

### DIFF
--- a/packages/client-node/integration/Main.spec.ts
+++ b/packages/client-node/integration/Main.spec.ts
@@ -20,6 +20,7 @@ import { voidTransactionLoc } from "./Void.js";
 import { votingProcess } from "./Vote.js";
 import { openIdentityLoc, openTransactionLoc, openCollectionLoc } from "./DirectLocOpen.js";
 import { invitedContributors } from "./InvitedContributors.js";
+import { recoverableSecrets } from "./Secrets.js";
 
 describe("Logion SDK", () => {
 
@@ -58,6 +59,10 @@ describe("Logion SDK", () => {
     it("enables protection", async () => {
         const identityLocs = await requestValidIdentity(state, state.requesterAccount);
         await enablesProtection(state, identityLocs);
+    });
+
+    it("enables recoverable secrets", async () => {
+        await recoverableSecrets(state);
     });
 
     it("provides vault", async () => {

--- a/packages/client-node/integration/Secrets.ts
+++ b/packages/client-node/integration/Secrets.ts
@@ -1,4 +1,4 @@
-import { ClosedIdentityLoc, waitFor } from "@logion/client";
+import { ClosedIdentityLoc } from "@logion/client";
 import { State } from "./Utils";
 
 export async function recoverableSecrets(state: State) {
@@ -18,26 +18,12 @@ export async function recoverableSecrets(state: State) {
     });
     expect(closedIdentityLoc).toBeInstanceOf(ClosedIdentityLoc);
 
-    // TODO should not be needed
-    closedIdentityLoc = await waitFor<ClosedIdentityLoc>({
-        predicate: state => state.data().secrets.length > 0,
-        producer: async prev => prev ? await prev.refresh() as ClosedIdentityLoc : closedIdentityLoc,
-    });
-
     let data = closedIdentityLoc.data();
-    console.log(data)
     expect(data.secrets.length).toBe(1);
     expect(data.secrets[0].name).toBe(name);
     expect(data.secrets[0].value).toBe(value);
 
-    console.log("removing")
     closedIdentityLoc = await closedIdentityLoc.removeSecret(name);
-
-    // TODO should not be needed
-    closedIdentityLoc = await waitFor<ClosedIdentityLoc>({
-        predicate: state => state.data().secrets.length === 0,
-        producer: async prev => prev ? await prev.refresh() as ClosedIdentityLoc : closedIdentityLoc,
-    });
 
     data = closedIdentityLoc.data();
     expect(data.secrets.length).toBe(0);

--- a/packages/client-node/integration/Secrets.ts
+++ b/packages/client-node/integration/Secrets.ts
@@ -1,0 +1,44 @@
+import { ClosedIdentityLoc, waitFor } from "@logion/client";
+import { State } from "./Utils";
+
+export async function recoverableSecrets(state: State) {
+    const { requesterAccount } = state;
+
+    const client = state.client.withCurrentAccount(requesterAccount);
+    let locsState = await client.locsState();
+
+    let closedIdentityLoc = locsState.closedLocs.Identity[0] as ClosedIdentityLoc;
+    expect(closedIdentityLoc).toBeInstanceOf(ClosedIdentityLoc);
+    const name = "Key";
+    const value = "Encrypted key";
+
+    closedIdentityLoc = await closedIdentityLoc.addSecret({
+        name,
+        value,
+    });
+    expect(closedIdentityLoc).toBeInstanceOf(ClosedIdentityLoc);
+
+    // TODO should not be needed
+    closedIdentityLoc = await waitFor<ClosedIdentityLoc>({
+        predicate: state => state.data().secrets.length > 0,
+        producer: async prev => prev ? await prev.refresh() as ClosedIdentityLoc : closedIdentityLoc,
+    });
+
+    let data = closedIdentityLoc.data();
+    console.log(data)
+    expect(data.secrets.length).toBe(1);
+    expect(data.secrets[0].name).toBe(name);
+    expect(data.secrets[0].value).toBe(value);
+
+    console.log("removing")
+    closedIdentityLoc = await closedIdentityLoc.removeSecret(name);
+
+    // TODO should not be needed
+    closedIdentityLoc = await waitFor<ClosedIdentityLoc>({
+        predicate: state => state.data().secrets.length === 0,
+        producer: async prev => prev ? await prev.refresh() as ClosedIdentityLoc : closedIdentityLoc,
+    });
+
+    data = closedIdentityLoc.data();
+    expect(data.secrets.length).toBe(0);
+}

--- a/packages/client-node/integration/VerifiedIssuer.ts
+++ b/packages/client-node/integration/VerifiedIssuer.ts
@@ -3,7 +3,8 @@ import {
     ClosedLoc,
     HashOrContent,
     AcceptedRequest,
-    PendingRequest, OpenLoc, MimeType, waitFor
+    PendingRequest, OpenLoc, MimeType, waitFor,
+    ClosedIdentityLoc
 } from "@logion/client";
 import { State, initAccountBalance } from "./Utils.js";
 import { NodeFile } from "../src/index.js";
@@ -48,7 +49,7 @@ export async function verifiedIssuer(state: State) {
         producer: prev => prev ? prev.refresh() as Promise<OpenLoc> : aliceOpen.refresh() as Promise<OpenLoc>,
         predicate: state => state.legalOfficer.canClose(false),
     });
-    let aliceClosed = await aliceOpen.legalOfficer.close({ signer, payload: { autoAck: false }}) as ClosedLoc;
+    let aliceClosed = await aliceOpen.legalOfficer.close({ signer, payload: { autoAck: false }}) as ClosedIdentityLoc;
     aliceClosed = await aliceClosed.legalOfficer.nominateIssuer({ signer });
 
     await initAccountBalance(state, newAccount);

--- a/packages/client-node/integration/Vote.ts
+++ b/packages/client-node/integration/Vote.ts
@@ -1,4 +1,4 @@
-import { ClosedLoc, PendingVote, Votes, waitFor } from "@logion/client";
+import { ClosedIdentityLoc, ClosedLoc, PendingVote, Votes, waitFor } from "@logion/client";
 import { State } from "./Utils.js";
 
 export async function votingProcess(state: State) {
@@ -6,7 +6,7 @@ export async function votingProcess(state: State) {
 
     const aliceClient = client.withCurrentAccount(alice.account);
     const closedIdentityLocs = await aliceClient.locsState({ spec: { ownerAddress: alice.account.address, locTypes: ["Identity"], statuses: ["CLOSED"] } });
-    const votableLoc = closedIdentityLocs.closedLocs["Identity"].find(loc => loc.data().requesterAccountId !== undefined && loc.data().requesterAccountId?.type === "Polkadot") as ClosedLoc;
+    const votableLoc = closedIdentityLocs.closedLocs["Identity"].find(loc => loc.data().requesterAccountId !== undefined && loc.data().requesterAccountId?.type === "Polkadot") as ClosedIdentityLoc;
 
     await votableLoc.legalOfficer.requestVote({ signer });
 

--- a/packages/client-node/jasmine-integration.json
+++ b/packages/client-node/jasmine-integration.json
@@ -7,10 +7,5 @@
     "../typescript.js"
   ],
   "stopSpecOnExpectationFailure": false,
-  "reporters": [
-    {
-      "name": "jasmine-spec-reporter#SpecReporter"
-    }
-  ],
   "random": false
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.45.0-4",
+  "version": "0.45.0-7",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/Loc.ts
+++ b/packages/client/src/Loc.ts
@@ -2074,7 +2074,7 @@ export class ClosedLoc extends LocRequestState {
 export class ClosedIdentityLoc extends ClosedLoc {
 
     async addSecret(secret: Secret): Promise<ClosedIdentityLoc> {
-        this.locSharedState.client.addSecret({
+        await this.locSharedState.client.addSecret({
             locId: this.locId,
             secret,
         });
@@ -2082,7 +2082,7 @@ export class ClosedIdentityLoc extends ClosedLoc {
     }
 
     async removeSecret(name: string): Promise<ClosedIdentityLoc> {
-        this.locSharedState.client.removeSecret({
+        await this.locSharedState.client.removeSecret({
             locId: this.locId,
             name,
         });

--- a/packages/client/src/LocClient.ts
+++ b/packages/client/src/LocClient.ts
@@ -157,6 +157,7 @@ export interface LocRequest {
     sponsorshipId?: string;
     fees?: BackendLocFees;
     collectionParams?: BackendCollectionParams;
+    secrets: Secret[];
 }
 
 export interface IdenfyVerificationSession {
@@ -2416,6 +2417,24 @@ export class AuthenticatedLocClient extends LocClient {
             throw newBackendError(e);
         }
     }
+
+    async addSecret(parameters: AddSecretParams & FetchParameters): Promise<void> {
+        try {
+            const { secret, locId } = parameters;
+            await this.backend().post(`/api/loc-request/${ locId.toString() }/secrets`, secret);
+        } catch(e) {
+            throw newBackendError(e);
+        }
+    }
+
+    async removeSecret(parameters: RefSecretParams & FetchParameters): Promise<void> {
+        try {
+            const { name, locId } = parameters;
+            await this.backend().delete(`/api/loc-request/${ locId.toString() }/secrets/${ encodeURIComponent(name) }`);
+        } catch(e) {
+            throw newBackendError(e);
+        }
+    }
 }
 
 export interface ReviewParams {
@@ -2519,4 +2538,12 @@ export interface AcceptIdentityLocParams {
 
 export interface AutoPublish {
     autoPublish: boolean;
+}
+
+export interface AddSecretParams {
+    secret: Secret;
+}
+
+export interface RefSecretParams {
+    name: string;
 }

--- a/packages/client/test/LocUtils.ts
+++ b/packages/client/test/LocUtils.ts
@@ -55,16 +55,16 @@ export function buildLocAndRequest(ownerAddress: ValidAccountId, status: LocRequ
     }
 }
 
-export function buildLocRequest(ownerAddress: ValidAccountId, status: LocRequestStatus, locType: LocType, voided?: boolean, requester: ValidAccountId = REQUESTER): LocRequest {
+export function buildLocRequest(ownerAccount: ValidAccountId, status: LocRequestStatus, locType: LocType, voided?: boolean, requester: ValidAccountId = REQUESTER): LocRequest {
     return {
         id: new UUID().toString(),
         createdOn: DateTime.now().toISO(),
-        description: `Some ${status} ${locType} LOC owned by ${ownerAddress}`,
+        description: `Some ${status} ${locType} LOC owned by ${ownerAccount.address}`,
         files: [ EXISTING_FILE ],
         links: [ EXISTING_LINK ],
         metadata: [],
         requesterAddress: requester,
-        ownerAddress: ownerAddress.address,
+        ownerAddress: ownerAccount.address,
         status,
         locType,
         voidInfo: voided ? { reason: "Some voiding reason.", voidedOn: DateTime.now().toISO() } : undefined,
@@ -74,11 +74,14 @@ export function buildLocRequest(ownerAddress: ValidAccountId, status: LocRequest
             legalFee: "0",
             collectionItemFee: "0",
             tokensRecordFee: "0",
-        }
+        },
+        secrets: locType === "Identity" && status === "CLOSED" ? [{ name: EXISTING_SECRET_NAME, value: EXISTING_SECRET_VALUE }] : [],
     };
 }
 
 export const ISSUER = ValidAccountId.polkadot("5FniDvPw22DMW1TLee9N8zBjzwKXaKB2DcvZZCQU5tjmv1kb");
+export const EXISTING_SECRET_NAME = "Exisint secret";
+export const EXISTING_SECRET_VALUE = "Some encrypted value";
 
 export function buildLoc(ownerAddress: ValidAccountId, status: LocRequestStatus, locType: LocType, voidInfo?: VoidInfo, requester: ValidAccountId = REQUESTER): LegalOfficerCase {
     return {


### PR DESCRIPTION
* Follow-up of https://github.com/logion-network/logion-api/pull/261
* Actually use backend resources (see https://github.com/logion-network/logion-backend-ts/pull/305)
* Remaining issue: in the integration tests, a `waitFor` is needed for the test to pass which should not be needed. There seems to be some kind of caching issue but further investigation is still needed.
* Nomination and dismissal of VIs are moved to `ClosedIdentityLoc` LLO commands.

logion-network/logion-internal#1252