### PR TITLE
Handle all transaction statuses

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.46.0",
+  "version": "0.46.1-1",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",


### PR DESCRIPTION
* Be robust to signer callback failures (i.e. thrown errors)
* Explicitly handle "final" transaction statuses (even if `canUnsub` does not)
* Reject `signAndSend` promise for all erroneous statuses

logion-network/logion-internal#1311