### PR TITLE
Human readable sign-in

### DIFF
--- a/packages/client-node/docker-compose.yml
+++ b/packages/client-node/docker-compose.yml
@@ -24,7 +24,8 @@ services:
       - IPFS_HOST=/dns4/ipfs1/tcp/5001
       - IPFS_MIN_REPLICA=1
       - IPFS_MAX_REPLICA=2
-      - ENC_PASSWORD=test
+      - ENC_PASSWORD_5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY=test1
+      - ENC_PASSWORD_5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y=test2
     depends_on:
       - private-database1
       - ipfs-cluster1
@@ -79,7 +80,7 @@ services:
       - IPFS_HOST=/dns4/ipfs2/tcp/5001
       - IPFS_MIN_REPLICA=1
       - IPFS_MAX_REPLICA=2
-      - ENC_PASSWORD=test
+      - ENC_PASSWORD_5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty=test
     depends_on:
       - private-database2
       - ipfs-cluster2

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logion/client",
-  "version": "0.46.1-1",
+  "version": "0.46.1-2",
   "description": "logion SDK for client applications",
   "main": "dist/index.js",
   "packageManager": "yarn@3.2.0",

--- a/packages/client/src/AuthenticationClient.ts
+++ b/packages/client/src/AuthenticationClient.ts
@@ -47,17 +47,14 @@ export class AuthenticationClient {
         const addresses = validAccountIds.map(validAccountId => validAccountId.toKey());
         const signInResponse = await axios.post("/api/auth/sign-in", { addresses });
         const sessionId = signInResponse.data.sessionId;
-        const attributes = [ sessionId ];
 
         const signatures: Record<string, AuthenticationSignature> = {};
         for(const validAccountId of validAccountIds) {
             const signedOn = DateTime.now();
             const signature = await signer.signRaw({
                 signerId: validAccountId,
-                resource: 'authentication',
-                operation: 'login',
                 signedOn,
-                attributes,
+                sessionId,
             });
             signatures[validAccountId.toKey()] = {
                 signature: signature.signature,
@@ -66,7 +63,7 @@ export class AuthenticationClient {
             };
         }
 
-        const authenticateResponse = await axios.post(`/api/auth/${sessionId}/authenticate`, {
+        const authenticateResponse = await axios.post(`/api/auth/${sessionId}/authenticate/v2`, {
             signatures
         });
         const authenticatedAddresses: AuthenticationResponse = authenticateResponse.data.tokens;

--- a/packages/client/src/Signer.ts
+++ b/packages/client/src/Signer.ts
@@ -5,7 +5,6 @@ import { ISubmittableResult } from '@polkadot/types/types';
 import { ExtrinsicStatus } from '@polkadot/types/interfaces/author';
 import { Registry } from '@polkadot/types-codec/types';
 import { base64Encode } from '@polkadot/util-crypto';
-import { stringToHex } from '@polkadot/util';
 import { Hash } from 'fast-sha256';
 import { DateTime } from "luxon";
 import { toIsoString } from "./DateTimeUtil.js";
@@ -13,10 +12,8 @@ import { requireDefined } from "./assertions.js";
 
 export interface SignRawParameters {
     signerId: ValidAccountId;
-    resource: string;
-    operation: string;
     signedOn: DateTime;
-    attributes: string[];
+    sessionId: string;
 }
 
 export type SignatureType = "POLKADOT" | "ETHEREUM" | "CROSSMINT_ETHEREUM" | "MULTIVERSX";
@@ -107,13 +104,7 @@ export abstract class BaseSigner implements FullSigner {
     abstract signToHex(signerId: ValidAccountId, message: string): Promise<TypedSignature>;
 
     buildMessage(parameters: SignRawParameters): string {
-        return stringToHex(hashAttributes(this.buildAttributes(parameters)));
-    }
-
-    buildAttributes(parameters: SignRawParameters): string[] {
-        const signedOn = toIsoString(parameters.signedOn);
-        const attributes = [parameters.resource, parameters.operation, signedOn];
-        return attributes.concat(parameters.attributes);
+        return `logion-auth: ${ parameters.sessionId } on ${ toIsoString(parameters.signedOn) }`
     }
 
     async signAndSend(parameters: SignParameters): Promise<SuccessfulSubmission> {

--- a/packages/client/test/AuthenticationClient.spec.ts
+++ b/packages/client/test/AuthenticationClient.spec.ts
@@ -111,10 +111,8 @@ function setupSignIn(axiosInstance: Mock<AxiosInstance>, validAccountIds: ValidA
 function setupSignatures(signer: Mock<RawSigner>, addresses: ValidAccountId[], sessionId: string, signatures: string[]) {
     for(let i = 0; i < addresses.length; ++i) {
         signer.setup(instance => instance.signRaw(It.Is<SignRawParameters>(params =>
-            params.resource === "authentication"
-            && params.signerId === addresses[i]
-            && params.operation === "login"
-            && params.attributes[0] === sessionId
+            params.signerId === addresses[i]
+            && params.sessionId === sessionId
         ))).returns(Promise.resolve({ signature: signatures[i], type: "POLKADOT"}));
     }
 }
@@ -131,7 +129,7 @@ function setupAuthenticate(axiosInstance: Mock<AxiosInstance>, accounts: ValidAc
     authenticateResponse.setup(instance => instance.data).returns({
         tokens
     });
-    axiosInstance.setup(instance => instance.post(`/api/auth/${sessionId}/authenticate`, It.Is<any>(body =>
+    axiosInstance.setup(instance => instance.post(`/api/auth/${sessionId}/authenticate/v2`, It.Is<any>(body =>
         bodyIncludesSignatures(body, accounts, signatures)
     ))).returns(Promise.resolve(authenticateResponse.object()));
 }


### PR DESCRIPTION
Provide a short yet human-readable message for authentication:
Example: `logion-auth: b8c2d824-2c60-4153-8b9d-01ede3aaed48 on 2024-07-01T12:29:27.562+02:00`.
Additionally, this PR fixes encryption passwords in integration tests.

logion-network/logion-internal#1298